### PR TITLE
Add support for referenced functions

### DIFF
--- a/src/form/checkboxFormItem.ts
+++ b/src/form/checkboxFormItem.ts
@@ -1,15 +1,13 @@
-import { CheckboxFormItem as CheckboxFormItemTemplate, InitFunctionString, ValueString, FormItemType } from "src/template/templateTypes";
+import { CheckboxFormItem as CheckboxFormItemTemplate, FormItemType } from "src/template/templateTypes";
 import { FormItemBase } from "./formItem";
 import { ExtendedSetting } from "src/ui/settingsExtension";
+import { FormItemFunctionProcessor } from "./formItemFunctionProcessor";
 
 export class CheckboxFormItem extends FormItemBase<boolean> {
 
-    constructor(src: CheckboxFormItemTemplate) {
+    constructor(src: CheckboxFormItemTemplate, funtionProcessor: FormItemFunctionProcessor) {
         CheckboxFormItem.assertType(src.type);
-
-        const initValue = CheckboxFormItem.getInitValue(src.init);
-
-        super(src.id, src.type, initValue, src.get, src.form);
+        super(src.id, src.type, funtionProcessor, src.init, src.get, src.form);
     }
 
     protected assignToFormImpl(contentEl: HTMLElement): void {
@@ -17,27 +15,21 @@ export class CheckboxFormItem extends FormItemBase<boolean> {
             .setName(this._title)
             .setDesc(this._description)
             .addToggle(toggle => toggle
-                .setValue(this.value)
+                .setValue(this.value!)
                 .onChange(newVal => this.value = newVal)
             );
     }
 
     protected getFunctionDefault(): string {
-        return String(this.value);
+        return String(this.value!);
     }
 
-    private static getInitValue(src?: InitFunctionString | ValueString): boolean {
-        if (!src) {
-            return false;
-        }
+    protected getInitValueFromString(valStr: string): boolean {
+        return valStr.toLowerCase() === 'true';
+    }
 
-        if (src.startsWith('f:')) {
-            return FormItemBase.executeInitFunction<boolean>(src.slice(2));
-        } else if (src.startsWith('v:')) {
-            return src.slice(2).toLowerCase() === 'true';
-        } else {
-            throw new Error(`Unsupported init value: ${src}`);
-        }
+    protected getInitValueDefault(): boolean {
+        return false;
     }
 
     private static assertType(type: FormItemType): void {

--- a/src/form/dateTimeFormItem.ts
+++ b/src/form/dateTimeFormItem.ts
@@ -1,18 +1,16 @@
-import { DateFormItem as DateFormItemTemplate, InitFunctionString, ValueString, FormItemType } from "src/template/templateTypes";
+import { DateFormItem as DateFormItemTemplate, FormItemType } from "src/template/templateTypes";
 import { FormItemBase } from "./formItem";
 import { ExtendedSetting } from "src/ui/settingsExtension";
 import { DateTimeComponent } from "src/ui/dateTimeComponent";
+import { FormItemFunctionProcessor } from "./formItemFunctionProcessor";
 
 const MUSTACHE_TEMPLATE_REGEX = /[{]{2}.+[}]{2}/;
 
 export class DateTimeFormItem extends FormItemBase<Date> {
 
-    constructor(src: DateFormItemTemplate) {
+    constructor(src: DateFormItemTemplate, funtionProcessor: FormItemFunctionProcessor) {
         DateTimeFormItem.assertType(src.type);
-
-        const initValue = DateTimeFormItem.getInitValue(src.init);
-
-        super(src.id, src.type, initValue, src.get, src.form);
+        super(src.id, src.type, funtionProcessor, src.init, src.get, src.form);
     }
 
     protected assignToFormImpl(contentEl: HTMLElement): void {
@@ -38,7 +36,7 @@ export class DateTimeFormItem extends FormItemBase<Date> {
 
     private configureComponent(): (component: DateTimeComponent) => any {
         return component => component
-            .setValue(this.value)
+            .setValue(this.value!)
             .onChange(newVal => this.value = newVal);
     }
 
@@ -63,22 +61,16 @@ export class DateTimeFormItem extends FormItemBase<Date> {
         return window.moment(this.value).format(templateText);
     }
 
-    private static getInitValue(src?: InitFunctionString | ValueString): Date {
-        if (!src) {
-            return new Date();
-        }
-
-        if (src.startsWith('f:')) {
-            return FormItemBase.executeInitFunction<Date>(src.slice(2));
-        } else if (src.startsWith('v:')) {
-            const parsed = new Date(src.slice(2));
+    protected getInitValueFromString(valStr: string): Date {
+        const parsed = new Date(valStr);
             if (isNaN(parsed.getTime())) {
-                throw new Error(`Invalid date init value: ${src}`);
+                throw new Error(`Invalid date init value: ${valStr}`);
             }
             return parsed;
-        } else {
-            throw new Error(`Unsupported init value: ${src}`);
-        }
+    }
+
+    protected getInitValueDefault(): Date {
+        return new Date();
     }
 
     private static assertType(type: FormItemType): void {

--- a/src/form/dropdownFormItem.ts
+++ b/src/form/dropdownFormItem.ts
@@ -1,6 +1,7 @@
-import { DropdownFormItem as DropdownFormItemTemplate, FormItemType, InitFunctionString, ValueString } from "src/template/templateTypes";
+import { DropdownFormItem as DropdownFormItemTemplate, FormItemType, InitFunctionType, ValueString } from "src/template/templateTypes";
 import { FormItemBase } from "./formItem";
 import { ExtendedSetting } from "src/ui/settingsExtension";
+import { FormItemFunctionProcessor } from "./formItemFunctionProcessor";
 
 interface DropdownOption {
     k: string;
@@ -11,33 +12,21 @@ interface DropdownOptionInput extends DropdownOption {
     s?: boolean;
 }
 
-interface InitResult {
-    opts: Record<string, string>;
-    selected: string;
-}
-
 export class DropdownFormItem extends FormItemBase<DropdownOption[]> {
     
-    private readonly _opts: Record<string, string>;
-    private readonly _selected: string;
+    private _opts: Record<string, string>;
+    private _selected: string;
 
-    constructor(src: DropdownFormItemTemplate) {
+    constructor(src: DropdownFormItemTemplate, funtionProcessor: FormItemFunctionProcessor) {
         DropdownFormItem.assertType(src.type);
+        super(src.id, src.type, funtionProcessor, src.init, src.get, src.form);
 
-        const {opts, selected} = DropdownFormItem.initSource(src.id, src.init);
-        const initValue: DropdownOption[] = [{
-            k: selected,
-            v: opts[selected],
-        }];
-
-        super(src.id, src.type, initValue, src.get, src.form);
-        
-        this._opts = opts;
-        this._selected = selected;
+        this._opts = {};
+        this._selected = "";
     }
 
     protected getFunctionDefault():string {
-        return this.value[0].v;
+        return this.value![0].v;
     }
 
     protected assignToFormImpl(contentEl: HTMLElement): void {
@@ -52,37 +41,29 @@ export class DropdownFormItem extends FormItemBase<DropdownOption[]> {
             );
     }
 
-    private static initSource(id: string, src?:  InitFunctionString | ValueString): InitResult {
-        if (!src) {
-            throw new Error(`Default value is not supported for '${id}' form item`);
+    protected getInitValueDefault(): DropdownOption[] {
+        throw new Error(`Default value is not supported for '${this.id}' form item`);
+    }
+
+    protected getInitValueFromString(valStr: string): DropdownOption[] {
+        return JSON.parse(valStr);
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+
+        if (this.value!.length === 0) {
+            throw new Error(`Init value can't be empty for for '${this.id}' form item`);
         }
 
-        let data: DropdownOptionInput[];
-        if (src.startsWith('f:')) {
-            data = FormItemBase.executeInitFunction<DropdownOptionInput[]>(src.slice(2));
-        } else if (src.startsWith('v:')) {
-            data = JSON.parse(src.slice(2));
-        } else {
-            throw new Error(`Invalid init value: ${src}`);
-        }
-
-        if (data.length === 0) {
-            throw new Error(`Init value can't be empty for for '${id}' form item`);
-        }
-
-        let result: InitResult = {
-            opts: {},
-            selected: data[0].k,
-        };
-
+        const data = this.value! as DropdownOptionInput[];
+        
         data.forEach(item => {
-            result.opts[item.k] = item.v;
+            this._opts[item.k] = item.v;
             if (item.s) {
-                result.selected = item.k;
+                this._selected = item.k;
             }
         });
-
-        return result;
     }
 
     private static assertType (type: FormItemType): void {

--- a/src/form/fileFormItem.ts
+++ b/src/form/fileFormItem.ts
@@ -1,7 +1,8 @@
 import { normalizePath } from "obsidian";
 import { FormItemBase } from "./formItem";
-import { FormItemForm, GetFunctionString, TemplateString, ValueString } from "src/template/templateTypes";
+import { FormItemForm, GetFunctionType, TemplateString, ValueString } from "src/template/templateTypes";
 import { ExtendedSetting } from "src/ui/settingsExtension";
+import { FormItemFunctionProcessor } from "./formItemFunctionProcessor";
 
 // https://docs.obsidian.md/Plugins/User+interface/Modals#Select+from+list+of+suggestions
 abstract class FileInfoFormItem extends FormItemBase<string> {
@@ -13,21 +14,28 @@ abstract class FileInfoFormItem extends FormItemBase<string> {
         title: string,
         description: string,
         placeholder: string,
-        getFunc?: GetFunctionString | TemplateString | ValueString) {
+        funtionProcessor: FormItemFunctionProcessor,
+        getFunc?: GetFunctionType | TemplateString | ValueString) {
 
         let formDisplay: FormItemForm | undefined = undefined;
         
-        const initValue: string = "";
-        
         if (!getFunc) {
-            formDisplay = { 
+            formDisplay = {
                 title: title,
                 description: description,
             };
         }
 
-        super(id, 'text', initValue, getFunc, formDisplay);
+        super(id, 'text', funtionProcessor, undefined, getFunc, formDisplay);
         this._placeholder = placeholder;
+    }
+
+    protected getInitValueFromString(valStr: string): string {
+        return valStr;
+    }
+
+    protected getInitValueDefault(): string {
+        return "";
     }
     
     protected assignToFormImpl(contentEl: HTMLElement): void {
@@ -36,7 +44,7 @@ abstract class FileInfoFormItem extends FormItemBase<string> {
             .setDesc(this._description)
             .addText(text => text
                 .setPlaceholder(this._placeholder)
-                .setValue(this.value)
+                .setValue(this.value!)
                 .onChange(newVal => this.value = newVal)
             );
     }
@@ -47,7 +55,7 @@ abstract class FileInfoFormItem extends FormItemBase<string> {
     }
 
     protected getFunctionDefault(): string {
-        return this.value;
+        return this.value!;
     }
 }
 
@@ -58,8 +66,8 @@ export class FileNameFormItem extends FileInfoFormItem {
     private static readonly _title: string = "Name of created note";
     private static readonly _placeholder: string = "My Fancy Note";
 
-    constructor (getFunc?: GetFunctionString | TemplateString | ValueString) {
-        super(FileNameFormItem.FormFieldId, "File name", FileNameFormItem._title, FileNameFormItem._placeholder, getFunc);
+    constructor (funtionProcessor: FormItemFunctionProcessor, getFunc?: GetFunctionType | TemplateString | ValueString) {
+        super(FileNameFormItem.FormFieldId, "File name", FileNameFormItem._title, FileNameFormItem._placeholder, funtionProcessor, getFunc);
     }
 }
 
@@ -70,7 +78,7 @@ export class FileLocationFormItem extends FileInfoFormItem {
     private static readonly _title: string = "Folder where note will be placed";
     private static readonly _placeholder: string = "/some/path/";
 
-    constructor (getFunc?: GetFunctionString | TemplateString | ValueString) {
-        super(FileLocationFormItem.FormFieldId, "File location", FileLocationFormItem._title, FileLocationFormItem._placeholder, getFunc);
+    constructor (funtionProcessor: FormItemFunctionProcessor, getFunc?: GetFunctionType | TemplateString | ValueString) {
+        super(FileLocationFormItem.FormFieldId, "File location", FileLocationFormItem._title, FileLocationFormItem._placeholder, funtionProcessor, getFunc);
     }
 }

--- a/src/form/formItem.ts
+++ b/src/form/formItem.ts
@@ -1,5 +1,6 @@
 import Mustache from 'mustache';
-import { FormItemForm, FormItemType, GetFunctionString, TemplateString, ValueString } from "src/template/templateTypes";
+import { FormItemForm, FormItemType, GetFunctionType, InitFunctionType, TemplateString, ValueString } from "src/template/templateTypes";
+import { FormItemFunctionProcessor } from './formItemFunctionProcessor';
 
 export interface FormItem {
     value: any;
@@ -9,33 +10,37 @@ export interface FormItem {
 
     assignToForm(contentEl: HTMLElement): void;
     get(view: Record<string, any>): string;
+    initialize(): Promise<void>;
 }
 
 export abstract class FormItemBase<TValue> implements FormItem {
 
-    value: TValue;
+    value: TValue | undefined;
 
     readonly id: string;
     readonly type: FormItemType;
 
     private readonly _assignToForm?: (contentEl: HTMLElement) => void;
-    private readonly _getFunc?: GetFunctionString | TemplateString | ValueString;
+    private readonly _getFunc?: GetFunctionType | TemplateString | ValueString;
+    private readonly _initFunc?: InitFunctionType | ValueString;
 
     protected readonly _title: string;
     protected readonly _description: string;
-
+    protected readonly _funtionProcessor: FormItemFunctionProcessor; 
 
     protected constructor(
         id: string, 
         type: FormItemType, 
-        initValue: TValue, 
-        getFunc?: GetFunctionString | TemplateString | ValueString, 
+        funtionProcessor: FormItemFunctionProcessor,
+        initFunc?: InitFunctionType | ValueString, 
+        getFunc?: GetFunctionType | TemplateString | ValueString, 
         formDisplay?: FormItemForm
     ) {
         this.id = id;
         this.type = type;
-        this.value = initValue;
+        this._initFunc = initFunc;
         this._getFunc = getFunc;
+        this._funtionProcessor = funtionProcessor;
 
         this._title = "";
         this._description = "";
@@ -46,6 +51,25 @@ export abstract class FormItemBase<TValue> implements FormItem {
             this._description = formDisplay.description ?? "";
         }
     }
+
+    async initialize(): Promise<void> {
+        if (this._initFunc) {
+            if (this._initFunc.startsWith('f:')) {
+                this.value = this._funtionProcessor.executeFunction<TValue>(this._initFunc.slice(2));
+            } else if (this._initFunc.startsWith('ref:')) {
+                this.value = await this._funtionProcessor.executeRefFunction<TValue>(this._initFunc.slice(4));
+            } else if (this._initFunc.startsWith('v:')) {
+                this.value = this.getInitValueFromString(this._initFunc.slice(2));
+            } else {
+                throw new Error(`Unsupported init function: ${this._initFunc}`);
+            }
+        } else {
+            this.value = this.getInitValueDefault();
+        }
+    }
+
+    protected abstract getInitValueFromString(valStr: string): TValue;
+    protected abstract getInitValueDefault(): TValue;
 
     assignToForm(contentEl: HTMLElement): void {
         if (this._assignToForm) {
@@ -84,10 +108,5 @@ export abstract class FormItemBase<TValue> implements FormItem {
 
     protected getValueImpl(valueText: string, _: Record<string, any>) : string {
         return valueText;
-    }
-
-    protected static executeInitFunction<TResult>(funcText: string): TResult {
-        const func = eval(`(${funcText})`) as () => TResult;
-        return func();
     }
 }

--- a/src/form/formItemFunctionProcessor.ts
+++ b/src/form/formItemFunctionProcessor.ts
@@ -1,0 +1,79 @@
+import Mustache from 'mustache';
+import { App, normalizePath, TFile } from "obsidian";
+import { NoteFromFormPluginSettings } from 'src/pluginSettings';
+import { TemplateIndexItem } from "src/template/templateIndex";
+
+export class FormItemFunctionProcessor {
+    private readonly _currentTemplate:TemplateIndexItem;
+    private readonly _app: App;
+    private readonly _settings: NoteFromFormPluginSettings;
+
+    constructor(currentTemplate: TemplateIndexItem, app: App, settings: NoteFromFormPluginSettings) {
+        this._currentTemplate = currentTemplate;
+        this._app = app;
+        this._settings = settings;
+    }
+
+    renderMustacheTemplate(templateText: string, view: Record<string, any>): string {
+        return Mustache.render(templateText, view, {}, { escape: (val: string) => val });
+    }
+
+    executeFunction<TResult>(funcText: string): TResult {
+        const func = eval(`(${funcText})`) as () => TResult;
+        return func();
+    }
+
+    executeFunctionWithParam<TResult, TArgs extends any[]>(funcText: string, ...args: TArgs): TResult {
+        const func = eval(`(${funcText})`) as (...args: TArgs) => TResult;
+        return func(...args);
+    }
+
+    async executeRefFunction<TResult>(ref: string): Promise<TResult> {
+        const funcText = await this.getFunctionText(ref);
+        return this.executeFunction<TResult>(funcText);
+    }
+
+    async executeRefFunctionWithParam<TResult, TArgs extends any[]>(ref: string, ...args: TArgs): Promise<TResult> {
+        const funcText = await this.getFunctionText(ref);
+        return this.executeFunctionWithParam<TResult, TArgs>(funcText, ...args);
+    }
+
+    private async getFunctionText(ref: string): Promise<string> {
+        const refParts = ref.split(':');
+        let file: TFile;
+        let funcName: string;
+
+        switch(refParts.length) {
+            case 1:
+                file = this._currentTemplate.file;
+                funcName = refParts[0];
+                break;
+            case 2:
+                const filePath = normalizePath(refParts[0]);
+                funcName = refParts[1];
+                file = this._app.vault.getFileByPath(filePath) as TFile;
+                if (!file) {
+                    throw new Error(`File not found for reference: ${filePath}`);
+                }
+                break;
+            default:
+                throw new Error(`Invalid reference format: ${ref}`);
+        }
+
+        const fileContent = await this._app.vault.cachedRead(file);
+        const pattern = this.getRegexForFunction(funcName);
+        const match = fileContent.match(pattern);
+        if (!match) {
+            throw new Error(`Function '${funcName}' not found in file: ${file.path}`);
+        }
+
+        return match[1];
+    }
+
+    private getRegexForFunction(funcName: string): RegExp {
+        return new RegExp(
+            '^```js:' + this._settings.templatePropertyName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ':' + funcName + '\\s*\\n([\\s\\S]*?)\\n```$',
+            'm'
+        );
+    }
+}

--- a/src/form/formItemManager.ts
+++ b/src/form/formItemManager.ts
@@ -7,41 +7,50 @@ import { DateTimeFormItem } from "./dateTimeFormItem";
 import { CheckboxFormItem } from "./checkboxFormItem";
 import { DropdownFormItem } from "./dropdownFormItem";
 import { NoteFromFormPluginSettings } from "src/pluginSettings";
+import { FormItemFunctionProcessor } from "./formItemFunctionProcessor";
 
 export class FormItemsManager {
-    static getFormItems(template: NoteTemplate, settings: NoteFromFormPluginSettings): FormItem[] {
-        
+    
+    static async getFormItems(template: NoteTemplate, functionProcessor: FormItemFunctionProcessor, settings: NoteFromFormPluginSettings): Promise<FormItem[]> {
         const fileLocationsSrc = template["file-location"] ?? `v:${settings.templatesFolderLocation}`;
-        const result: FormItem[] = [
-            new FileNameFormItem(template["file-name"]),
-            new FileLocationFormItem(fileLocationsSrc),
-        ];
+        const result: FormItem[] = [];
+
+        let formItem: FormItem = new FileNameFormItem(functionProcessor, template["file-name"]);
+        await formItem.initialize();
+        result.push(formItem);
+
+        formItem = new FileLocationFormItem(functionProcessor, fileLocationsSrc);
+        await formItem.initialize();
+        result.push(formItem);
 
         for (const item of template["form-items"] ?? []) {
             const itemType = item.type;
-
+            
             switch (itemType) {
                 case 'text':
                 case 'textArea':
-                    result.push(new TextFormItem(item));
+                    formItem = new TextFormItem(item, functionProcessor);
                     break;
                 case 'number':
-                    result.push(new NumberFormItem(item));
+                    formItem = new NumberFormItem(item, functionProcessor);
                     break;
                 case 'date':
                 case 'time':
                 case 'dateTime':
-                    result.push(new DateTimeFormItem(item));
+                    formItem = new DateTimeFormItem(item, functionProcessor);
                     break;
                 case 'checkbox':
-                    result.push(new CheckboxFormItem(item));
+                    formItem = new CheckboxFormItem(item, functionProcessor);
                     break;
                 case 'dropdown':
-                    result.push(new DropdownFormItem(item));
+                    formItem = new DropdownFormItem(item, functionProcessor);
                     break;
                 default:
                     throw new Error(`Unsupported type: ${itemType}`);
             }
+
+            await formItem.initialize();
+            result.push(formItem);
         }
 
         return result;

--- a/src/form/numberFormItem.ts
+++ b/src/form/numberFormItem.ts
@@ -1,15 +1,13 @@
-import { NumberFormItem as NumberFormItemTemplate, InitFunctionString, ValueString, FormItemType } from "src/template/templateTypes";
+import { NumberFormItem as NumberFormItemTemplate, FormItemType } from "src/template/templateTypes";
 import { FormItemBase } from "./formItem";
 import { ExtendedSetting } from "src/ui/settingsExtension";
+import { FormItemFunctionProcessor } from "./formItemFunctionProcessor";
 
 export class NumberFormItem extends FormItemBase<number> {
 
-    constructor(src: NumberFormItemTemplate) {
+    constructor(src: NumberFormItemTemplate, funtionProcessor: FormItemFunctionProcessor) {
         NumberFormItem.assertType(src.type);
-
-        const initValue = NumberFormItem.getInitValue(src.init);
-
-        super(src.id, src.type, initValue, src.get, src.form);
+        super(src.id, src.type, funtionProcessor, src.init, src.get, src.form);
     }
 
     protected assignToFormImpl(contentEl: HTMLElement): void {
@@ -17,7 +15,7 @@ export class NumberFormItem extends FormItemBase<number> {
             .setName(this._title)
             .setDesc(this._description)
             .addNumber(comp => comp
-                .setValue(this.value)
+                .setValue(this.value!)
                 .onChange(newVal => {
                     const parsed = Number(newVal);
                     if (!isNaN(parsed)) {
@@ -28,25 +26,19 @@ export class NumberFormItem extends FormItemBase<number> {
     }
 
     protected getFunctionDefault(): string {
-        return String(this.value);
+        return String(this.value!);
     }
 
-    private static getInitValue(src?: InitFunctionString | ValueString): number {
-        if (!src) {
-            return 0;
-        }
-
-        if (src.startsWith('f:')) {
-            return FormItemBase.executeInitFunction<number>(src.slice(2));
-        } else if (src.startsWith('v:')) {
-            const parsed = Number(src.slice(2));
+    protected getInitValueFromString(valStr: string): number {
+        const parsed = Number(valStr);
             if (isNaN(parsed)) {
-                throw new Error(`Invalid number init value: ${src}`);
+                throw new Error(`Invalid number init value: ${valStr}`);
             }
             return parsed;
-        } else {
-            throw new Error(`Unsupported init value: ${src}`);
-        }
+    }
+
+    protected getInitValueDefault(): number {
+        return 0;
     }
 
     private static assertType(type: FormItemType): void {

--- a/src/form/textFormItem.ts
+++ b/src/form/textFormItem.ts
@@ -1,19 +1,16 @@
 import { TextAreaComponent, TextComponent } from "obsidian";
-import { TextFormItem as TextFormItemTemplate, InitFunctionString, ValueString, FormItemType } from "src/template/templateTypes";
+import { TextFormItem as TextFormItemTemplate, FormItemType } from "src/template/templateTypes";
 import { FormItemBase } from "./formItem";
 import { ExtendedSetting } from "src/ui/settingsExtension";
+import { FormItemFunctionProcessor } from "./formItemFunctionProcessor";
 
 export class TextFormItem extends FormItemBase<string> {
     
     private readonly _placeholder: string = "";
 
-    constructor (src: TextFormItemTemplate) {
-
+    constructor (src: TextFormItemTemplate, funtionProcessor: FormItemFunctionProcessor) {
         TextFormItem.assertType(src.type);
-
-        const initValue =  TextFormItem.getInitValue(src.init);
-
-        super(src.id, src.type, initValue, src.get, src.form);
+        super(src.id, src.type, funtionProcessor, src.init, src.get, src.form);
 
         if (src.form?.placeholder) {
             this._placeholder = src.form.placeholder;
@@ -40,27 +37,20 @@ export class TextFormItem extends FormItemBase<string> {
     private configureComponent() : (component: TextAreaComponent | TextComponent) => TextAreaComponent | TextComponent {
         return component => component
             .setPlaceholder(this._placeholder)
-            .setValue(this.value)
+            .setValue(this.value!)
             .onChange(newVal => this.value = newVal);
     }
 
     protected getFunctionDefault(): string {
-        return this.value;
+        return this.value!;
     }
 
-    private static getInitValue(src?: InitFunctionString | ValueString): string {
+    protected getInitValueFromString(valStr: string): string {
+        return valStr;
+    }
 
-        if (!src) {
-            return "";
-        }
-
-        if (src.startsWith('f:')) {
-            return FormItemBase.executeInitFunction(src.slice(2));
-        } else if (src.startsWith('v:')) {
-            return src.slice(2);
-        } else {
-            throw new Error(`Unsupported init value: ${src}`);
-        }
+    protected getInitValueDefault(): string {
+        return "";
     }
 
     private static assertType (type: FormItemType): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,8 +32,8 @@ export default class NoteFromFormPlugin extends Plugin {
         this.registerEvent(this.app.vault.on('delete', async (file) => await this.templateIndex.onVaultChange(file)));
         this.registerEvent(this.app.vault.on('modify', async (file) => await this.templateIndex.onVaultChange(file)));
         this.registerEvent(this.app.vault.on('rename', async (file) => await this.templateIndex.onVaultChange(file)));
-        this.registerEvent(this.app.workspace.on('file-menu', async (menu, file) => {
-            if (file instanceof TFile && await this.templateIndex.isInTemplatesFolder(file)) {
+        this.registerEvent(this.app.workspace.on('file-menu', (menu, file) => {
+            if (file instanceof TFile && this.templateIndex.isTemplateFile(file)) {
                 menu.addItem((item) => {
                     item.setTitle('Note From Form: Use template')
                         .setIcon('captions')

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,12 +28,12 @@ export default class NoteFromFormPlugin extends Plugin {
         this.addSettingTab(new NoteFromFormSettingsTab(this.app, this, this.settings, this.updateSettings.bind(this)));
 
         // listen for changes in vault to rebuild template index on fly
-        this.registerEvent(this.app.vault.on('create', (file) => this.templateIndex.onVaultChange(file)));
-        this.registerEvent(this.app.vault.on('delete', (file) => this.templateIndex.onVaultChange(file)));
-        this.registerEvent(this.app.vault.on('modify', (file) => this.templateIndex.onVaultChange(file)));
-        this.registerEvent(this.app.vault.on('rename', (file) => this.templateIndex.onVaultChange(file)));
-        this.registerEvent(this.app.workspace.on('file-menu', (menu, file) => {
-            if (file instanceof TFile && this.templateIndex.isInTemplatesFolder(file)) {
+        this.registerEvent(this.app.vault.on('create', async (file) => await this.templateIndex.onVaultChange(file)));
+        this.registerEvent(this.app.vault.on('delete', async (file) => await this.templateIndex.onVaultChange(file)));
+        this.registerEvent(this.app.vault.on('modify', async (file) => await this.templateIndex.onVaultChange(file)));
+        this.registerEvent(this.app.vault.on('rename', async (file) => await this.templateIndex.onVaultChange(file)));
+        this.registerEvent(this.app.workspace.on('file-menu', async (menu, file) => {
+            if (file instanceof TFile && await this.templateIndex.isInTemplatesFolder(file)) {
                 menu.addItem((item) => {
                     item.setTitle('Note From Form: Use template')
                         .setIcon('captions')
@@ -82,6 +82,7 @@ export default class NoteFromFormPlugin extends Plugin {
         if (!indexedTemplate) {
             return;
         }
+        
         try {
             await this.templateProcessor.useTemplate(indexedTemplate);
         } catch (e) {

--- a/src/template/schema.json
+++ b/src/template/schema.json
@@ -12,14 +12,54 @@
             "errorMessage": "must be a value string starting with 'v:' followed by at least one character"
         },
         "initFunctionType": {
-            "type": "string",
-            "pattern": "^f:(\\(.*\\)\\s*=>|function\\s*\\(.*\\)\\s*\\{).*$",
-            "errorMessage": "must be a function string starting with 'f:' followed by an anonymous function (e.g. f:() => value or f:function() { return value; })"
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^f:\\(.*\\)\\s*=>.*$",
+                    "errorMessage": "must be a function string starting with 'f:' followed by an arrow function (e.g. f:() => value)"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^f:function\\s*\\(.*\\)\\s*\\{.*\\}$",
+                    "errorMessage": "must be a function string starting with 'f:' followed by a function expression (e.g. f:function() { return value; })"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^ref:[a-zA-Z_$][a-zA-Z0-9_$]*$",
+                    "errorMessage": "must be a reference starting with 'ref:' followed by a valid function name (e.g. ref:myFunction)"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^ref:/[^:]+:[a-zA-Z_$][a-zA-Z0-9_$]*$",
+                    "errorMessage": "must be a reference starting with 'ref:' followed by a file path and function name (e.g. ref:/my/dir/functions.md:myFunc)"
+                }
+            ],
+            "errorMessage": "must be one of: f:<arrow function>, f:<function expression>, ref:<funcName>, or ref:<path>:<funcName>"
         },
         "getFunctionType": {
-            "type": "string",
-            "pattern": "^f:(\\(view\\)\\s*=>|function\\s*\\(view\\)\\s*\\{).*$",
-            "errorMessage": "must be a function string starting with 'f:' followed by an anonymous function that receives 'view' parameter (e.g. f:(view) => value or f:function(view) { return value; })"
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^f:\\(view\\)\\s*=>.*$",
+                    "errorMessage": "must be a function string starting with 'f:' followed by an arrow function receiving 'view' parameter (e.g. f:(view) => value)"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^f:function\\s*\\(view\\)\\s*\\{.*\\}$",
+                    "errorMessage": "must be a function string starting with 'f:' followed by a function expression receiving 'view' parameter (e.g. f:function(view) { return value; })"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^ref:[a-zA-Z_$][a-zA-Z0-9_$]*$",
+                    "errorMessage": "must be a reference starting with 'ref:' followed by a valid function name (e.g. ref:myFunction)"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^ref:/[^:]+:[a-zA-Z_$][a-zA-Z0-9_$]*$",
+                    "errorMessage": "must be a reference starting with 'ref:' followed by a file path and function name (e.g. ref:/my/dir/functions.md:myFunc)"
+                }
+            ],
+            "errorMessage": "must be one of: f:<arrow function with view>, f:<function expression with view>, ref:<funcName>, or ref:<path>:<funcName>"
         },
         "pathType": {
             "type": "string",

--- a/src/template/templateIndex.ts
+++ b/src/template/templateIndex.ts
@@ -34,20 +34,8 @@ export class TemplateIndex {
         }
     }
 
-    async isInTemplatesFolder(file: TFile): Promise<boolean> {
-        const templatesFolder = this.settings.templatesFolderLocation;
-        if (templatesFolder.length === 0) return false;
-
-        const normalizedFolder = normalizePath(templatesFolder);
-        const isInTemplatesFolder = file.path.startsWith(normalizedFolder + '/');
-        let isTemplate: boolean = false;
-
-        await this.fileManager.processFrontMatter(file, (frontmatter) => {
-            const propertyName = this.settings.templatePropertyName;
-            isTemplate = propertyName in frontmatter;
-        });
-
-        return isInTemplatesFolder && isTemplate;
+    isTemplateFile(file: TFile): boolean {
+        return this.items.some(item => item.file.path === file.path);
     }
 
     async update(file: TFile) {
@@ -100,5 +88,21 @@ export class TemplateIndex {
         const parts = relativePath.replace(/\.md$/, '').split('/');
         if (parts.length === 1) return parts[0];
         return parts.join('/');
+    }
+
+    private async isInTemplatesFolder(file: TFile): Promise<boolean> {
+        const templatesFolder = this.settings.templatesFolderLocation;
+        if (templatesFolder.length === 0) return false;
+
+        const normalizedFolder = normalizePath(templatesFolder);
+        const isInTemplatesFolder = file.path.startsWith(normalizedFolder + '/');
+        let isTemplate: boolean = false;
+
+        await this.fileManager.processFrontMatter(file, (frontmatter) => {
+            const propertyName = this.settings.templatePropertyName;
+            isTemplate = propertyName in frontmatter;
+        });
+
+        return isInTemplatesFolder && isTemplate;
     }
 }

--- a/src/template/templateIndex.ts
+++ b/src/template/templateIndex.ts
@@ -26,20 +26,28 @@ export class TemplateIndex {
         return this.items;
     }
 
-    onVaultChange(file: TAbstractFile) {
+    async onVaultChange(file: TAbstractFile) {
         if (!(file instanceof TFile)) return;
 
-        if (this.isInTemplatesFolder(file)) {
-            this.update(file);
+        if (await this.isInTemplatesFolder(file)) {
+            await this.update(file);
         }
     }
 
-    isInTemplatesFolder(file: TFile): boolean {
+    async isInTemplatesFolder(file: TFile): Promise<boolean> {
         const templatesFolder = this.settings.templatesFolderLocation;
         if (templatesFolder.length === 0) return false;
 
         const normalizedFolder = normalizePath(templatesFolder);
-        return file.path.startsWith(normalizedFolder + '/');
+        const isInTemplatesFolder = file.path.startsWith(normalizedFolder + '/');
+        let isTemplate: boolean = false;
+
+        await this.fileManager.processFrontMatter(file, (frontmatter) => {
+            const propertyName = this.settings.templatePropertyName;
+            isTemplate = propertyName in frontmatter;
+        });
+
+        return isInTemplatesFolder && isTemplate;
     }
 
     async update(file: TFile) {

--- a/src/template/templateProcessor.ts
+++ b/src/template/templateProcessor.ts
@@ -1,4 +1,4 @@
-import { App, FileManager, normalizePath, Notice, TFile, TFolder } from 'obsidian';
+import { App, normalizePath, Notice, TFile, TFolder } from 'obsidian';
 import Mustache from 'mustache';
 import { NoteFromFormPluginSettings } from '../pluginSettings';
 import { NoteTemplate } from './templateTypes';
@@ -8,6 +8,7 @@ import { InputFormModal } from 'src/ui/inputFormModal';
 import { TemplateIndexItem } from './templateIndex';
 import { FormItem } from 'src/form/formItem';
 import { FileLocationFormItem, FileNameFormItem } from 'src/form/fileFormItem';
+import { FormItemFunctionProcessor } from 'src/form/formItemFunctionProcessor';
 
 export class TemplateProcessor {
     private readonly _app: App;
@@ -57,7 +58,8 @@ export class TemplateProcessor {
         }
 
         const template = templateData as NoteTemplate;
-        const formItems = FormItemsManager.getFormItems(template, this._settings);
+        const functionProcessor = new FormItemFunctionProcessor(indexedTemplate, this._app, this._settings);
+        const formItems = await FormItemsManager.getFormItems(template, functionProcessor, this._settings);
 
         const inputForm = new InputFormModal(this._app, indexedTemplate, formItems, this.createNoteFromTemplate.bind(this));
         inputForm.open();

--- a/src/template/templateProcessor.ts
+++ b/src/template/templateProcessor.ts
@@ -106,6 +106,11 @@ export class TemplateProcessor {
             delete frontmatter[this._settings.templatePropertyName];
         });
 
+        const codeBlockPattern = this.getCodeBlockPattern();
+        await this._app.vault.process(file, (content: string) => {
+            return content.replace(codeBlockPattern, '');
+        });
+
         return file;
     }
 
@@ -113,5 +118,13 @@ export class TemplateProcessor {
         await this._app.vault.process(note, (content) => {
             return Mustache.render(content, viewModel, {}, { escape: (val: string) => val });
         });
+    }
+
+    private getCodeBlockPattern(): RegExp {
+        const propName = this._settings.templatePropertyName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return new RegExp(
+            '\\n?^```js:' + propName + ':[a-zA-Z_$][a-zA-Z0-9_$]*\\s*\\n[\\s\\S]*?\\n```$',
+            'gm'
+        );
     }
 }

--- a/src/template/templateTypes.ts
+++ b/src/template/templateTypes.ts
@@ -6,11 +6,20 @@ export type TemplateString = `t:${string}`;
 /** String prefixed with `v:` — a literal value, e.g. `"v:42"` */
 export type ValueString = `v:${string}`;
 
-/** String prefixed with `f:` — an init function (no params), e.g. `"f:() => 'default'"` */
-export type InitFunctionString = `f:${string}`;
+/** String prefixed with `f:` — an inline function, e.g. `"f:() => 'default'"` */
+export type FuncStringType = `f:${string}`;
 
-/** String prefixed with `f:` — a get function receiving `view`, e.g. `"f:(view) => view.name"` */
-export type GetFunctionString = `f:${string}`;
+/** String prefixed with `ref:` — a reference to a named function, e.g. `"ref:myFunc"` */
+export type FuncRefType = `ref:${string}`;
+
+/** String prefixed with `ref:` — a reference to a named function in a file, e.g. `"ref:/path/to/file.md:myFunc"` */
+export type FuncFileRefType = `ref:${string}:${string}`;
+
+/** An init function: inline function, function reference, or file function reference */
+export type InitFunctionType = FuncStringType | FuncRefType | FuncFileRefType;
+
+/** A get function: inline function with view param, function reference, or file function reference */
+export type GetFunctionType = FuncStringType | FuncRefType | FuncFileRefType;
 
 // ── Form item types ──
 
@@ -29,8 +38,8 @@ export interface BaseFormItem {
     id: string;
     type: FormItemType;
     form?: FormItemForm;
-    get?: GetFunctionString | TemplateString | ValueString;
-    init?: InitFunctionString | ValueString;
+    get?: GetFunctionType | TemplateString | ValueString;
+    init?: InitFunctionType | ValueString;
 }
 
 export interface TextFormItem extends BaseFormItem {
@@ -59,7 +68,7 @@ export type FormItem = TextFormItem | NumberFormItem | DateFormItem | CheckboxFo
 // ── Top-level template ──
 
 export interface NoteTemplate {
-    'file-name'?: TemplateString | ValueString | GetFunctionString;
-    'file-location'?: TemplateString | GetFunctionString | ValueString;
+    'file-name'?: TemplateString | ValueString | GetFunctionType;
+    'file-location'?: TemplateString | GetFunctionType | ValueString;
     'form-items'?: FormItem[];
 }

--- a/src/tests/checkboxFormItem.test.ts
+++ b/src/tests/checkboxFormItem.test.ts
@@ -13,42 +13,58 @@ jest.mock("src/ui/settingsExtension", () => {
     return { ExtendedSetting: jest.fn().mockImplementation(() => ({ ...mock })) };
 });
 
+const mockFunctionProcessor = {
+    renderMustacheTemplate: jest.fn(),
+    executeFunction: jest.fn().mockImplementation((funcText: string) => {
+        const func = eval(`(${funcText})`);
+        return func();
+    }),
+    executeFunctionWithParam: jest.fn(),
+    executeRefFunction: jest.fn(),
+    executeRefFunctionWithParam: jest.fn(),
+} as any;
+
 describe("CheckboxFormItem", () => {
 
     // ─── constructor ───
 
     describe("constructor", () => {
-        test("defaults to false when no init provided", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox" });
+        test("defaults to false when no init provided", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(false);
         });
 
-        test("parses v:true init value", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:true" });
+        test("parses v:true init value", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:true" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(true);
         });
 
-        test("parses v:false init value", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:false" });
+        test("parses v:false init value", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:false" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(false);
         });
 
-        test("parses v:TRUE case-insensitively", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:TRUE" });
+        test("parses v:TRUE case-insensitively", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:TRUE" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(true);
         });
 
-        test("evaluates f: init function", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "f:() => true" });
+        test("evaluates f: init function", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "f:() => true" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(true);
         });
 
         test("throws for unsupported type", () => {
-            expect(() => new CheckboxFormItem({ id: "cb1", type: "text" as any })).toThrow("Unsupported type");
+            expect(() => new CheckboxFormItem({ id: "cb1", type: "text" as any }, mockFunctionProcessor)).toThrow("Unsupported type");
         });
 
         test("sets id and type correctly", () => {
-            const item = new CheckboxFormItem({ id: "myCheck", type: "checkbox" });
+            const item = new CheckboxFormItem({ id: "myCheck", type: "checkbox" }, mockFunctionProcessor);
             expect(item.id).toBe("myCheck");
             expect(item.type).toBe("checkbox");
         });
@@ -57,28 +73,33 @@ describe("CheckboxFormItem", () => {
     // ─── getFunctionDefault (via get()) ───
 
     describe("get", () => {
-        test("returns 'true' when value is true and no getFunc", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:true" });
+        test("returns 'true' when value is true and no getFunc", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:true" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("true");
         });
 
-        test("returns 'false' when value is false and no getFunc", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox" });
+        test("returns 'false' when value is false and no getFunc", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("false");
         });
 
-        test("returns literal for v: getFunc", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", get: "v:yes" });
+        test("returns literal for v: getFunc", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", get: "v:yes" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("yes");
         });
 
-        test("invokes arrow function for f: getFunc", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", get: "f:(view)=>true" });
+        test("invokes arrow function for f: getFunc", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", get: "f:(view)=>true" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe(true);
         });
 
-        test("invokes regular function for f: getFunc", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", get: "f:function(view) { return true; }" });
+        test("invokes regular function for f: getFunc", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", get: "f:function(view) { return true; }" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe(true);
         });
     });
@@ -86,18 +107,50 @@ describe("CheckboxFormItem", () => {
     // ─── assignToForm ───
 
     describe("assignToForm", () => {
-        test("does nothing when no form display is configured", () => {
-            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox" });
+        test("does nothing when no form display is configured", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox" }, mockFunctionProcessor);
+            await item.initialize();
             // Should not throw
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("does not throw when form display is configured", () => {
+        test("does not throw when form display is configured", async () => {
             const item = new CheckboxFormItem({
                 id: "cb1", type: "checkbox",
                 form: { title: "My Checkbox", description: "desc" },
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
+        });
+    });
+
+    // ─── initialize ───
+
+    describe("initialize", () => {
+        test("value is undefined before initialize", () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "v:true" }, mockFunctionProcessor);
+            expect(item.value).toBeUndefined();
+        });
+
+        test("resolves ref: init via executeRefFunction", async () => {
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce(true);
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "ref:isChecked" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("isChecked");
+            expect(item.value).toBe(true);
+        });
+
+        test("resolves ref: with path via executeRefFunction", async () => {
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce(false);
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "ref:/funcs.md:isChecked" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("/funcs.md:isChecked");
+            expect(item.value).toBe(false);
+        });
+
+        test("throws for unsupported init prefix", async () => {
+            const item = new CheckboxFormItem({ id: "cb1", type: "checkbox", init: "x:bad" as any }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Unsupported init function");
         });
     });
 });

--- a/src/tests/dateFormItem.test.ts
+++ b/src/tests/dateFormItem.test.ts
@@ -50,16 +50,16 @@ describe("DateFormItem", () => {
             const item = new DateFormItem({ id: "d1", type: "date" }, mockFunctionProcessor);
             await item.initialize();
             const after = Date.now();
-            expect(item.value.getTime()).toBeGreaterThanOrEqual(before);
-            expect(item.value.getTime()).toBeLessThanOrEqual(after);
+            expect(item.value!.getTime()).toBeGreaterThanOrEqual(before);
+            expect(item.value!.getTime()).toBeLessThanOrEqual(after);
         });
 
         test("parses v: date init value", async () => {
             const item = new DateFormItem({ id: "d1", type: "date", init: "v:2025-01-15" }, mockFunctionProcessor);
             await item.initialize();
-            expect(item.value.getFullYear()).toBe(2025);
-            expect(item.value.getMonth()).toBe(0);
-            expect(item.value.getDate()).toBe(15);
+            expect(item.value!.getFullYear()).toBe(2025);
+            expect(item.value!.getMonth()).toBe(0);
+            expect(item.value!.getDate()).toBe(15);
         });
 
         test("throws for invalid v: date init value", async () => {
@@ -73,7 +73,7 @@ describe("DateFormItem", () => {
                 init: "f:() => new Date(2025, 0, 1)",
             }, mockFunctionProcessor);
             await item.initialize();
-            expect(item.value.getFullYear()).toBe(2025);
+            expect(item.value!.getFullYear()).toBe(2025);
         });
 
         test("accepts date type", () => {

--- a/src/tests/dateFormItem.test.ts
+++ b/src/tests/dateFormItem.test.ts
@@ -29,58 +29,72 @@ jest.mock("src/ui/dateTimeComponent", () => ({
     DateTimeComponent: jest.fn(),
 }));
 
+const mockFunctionProcessor = {
+    renderMustacheTemplate: jest.fn(),
+    executeFunction: jest.fn().mockImplementation((funcText: string) => {
+        const func = eval(`(${funcText})`);
+        return func();
+    }),
+    executeFunctionWithParam: jest.fn(),
+    executeRefFunction: jest.fn(),
+    executeRefFunctionWithParam: jest.fn(),
+} as any;
+
 describe("DateFormItem", () => {
 
     // ─── constructor ───
 
     describe("constructor", () => {
-        test("defaults to current date when no init provided", () => {
+        test("defaults to current date when no init provided", async () => {
             const before = Date.now();
-            const item = new DateFormItem({ id: "d1", type: "date" });
+            const item = new DateFormItem({ id: "d1", type: "date" }, mockFunctionProcessor);
+            await item.initialize();
             const after = Date.now();
             expect(item.value.getTime()).toBeGreaterThanOrEqual(before);
             expect(item.value.getTime()).toBeLessThanOrEqual(after);
         });
 
-        test("parses v: date init value", () => {
-            const item = new DateFormItem({ id: "d1", type: "date", init: "v:2025-01-15" });
+        test("parses v: date init value", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date", init: "v:2025-01-15" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value.getFullYear()).toBe(2025);
             expect(item.value.getMonth()).toBe(0);
             expect(item.value.getDate()).toBe(15);
         });
 
-        test("throws for invalid v: date init value", () => {
-            expect(() => new DateFormItem({ id: "d1", type: "date", init: "v:not-a-date" }))
-                .toThrow("Invalid date init value");
+        test("throws for invalid v: date init value", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date", init: "v:not-a-date" }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Invalid date init value");
         });
 
-        test("evaluates f: init function", () => {
+        test("evaluates f: init function", async () => {
             const item = new DateFormItem({
                 id: "d1", type: "date",
                 init: "f:() => new Date(2025, 0, 1)",
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value.getFullYear()).toBe(2025);
         });
 
         test("accepts date type", () => {
-            expect(() => new DateFormItem({ id: "d1", type: "date" })).not.toThrow();
+            expect(() => new DateFormItem({ id: "d1", type: "date" }, mockFunctionProcessor)).not.toThrow();
         });
 
         test("accepts time type", () => {
-            expect(() => new DateFormItem({ id: "d1", type: "time" })).not.toThrow();
+            expect(() => new DateFormItem({ id: "d1", type: "time" }, mockFunctionProcessor)).not.toThrow();
         });
 
         test("accepts dateTime type", () => {
-            expect(() => new DateFormItem({ id: "d1", type: "dateTime" })).not.toThrow();
+            expect(() => new DateFormItem({ id: "d1", type: "dateTime" }, mockFunctionProcessor)).not.toThrow();
         });
 
         test("throws for unsupported type", () => {
-            expect(() => new DateFormItem({ id: "d1", type: "text" as any }))
+            expect(() => new DateFormItem({ id: "d1", type: "text" as any }, mockFunctionProcessor))
                 .toThrow("Unsupported type");
         });
 
         test("sets id and type correctly", () => {
-            const item = new DateFormItem({ id: "myDate", type: "time" });
+            const item = new DateFormItem({ id: "myDate", type: "time" }, mockFunctionProcessor);
             expect(item.id).toBe("myDate");
             expect(item.type).toBe("time");
         });
@@ -89,43 +103,51 @@ describe("DateFormItem", () => {
     // ─── get ───
 
     describe("get", () => {
-        test("returns formatted date for date type (no getFunc)", () => {
-            const item = new DateFormItem({ id: "d1", type: "date", init: "v:2025-01-15" });
+        test("returns formatted date for date type (no getFunc)", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date", init: "v:2025-01-15" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("01/15/2025");
         });
 
-        test("returns formatted time for time type (no getFunc)", () => {
-            const item = new DateFormItem({ id: "d1", type: "time", init: "v:2025-01-15T14:30:45" });
+        test("returns formatted time for time type (no getFunc)", async () => {
+            const item = new DateFormItem({ id: "d1", type: "time", init: "v:2025-01-15T14:30:45" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("2:30:45 PM");
         });
 
-        test("returns formatted dateTime for dateTime type (no getFunc)", () => {
-            const item = new DateFormItem({ id: "d1", type: "dateTime", init: "v:2025-01-15T14:30:45" });
+        test("returns formatted dateTime for dateTime type (no getFunc)", async () => {
+            const item = new DateFormItem({ id: "d1", type: "dateTime", init: "v:2025-01-15T14:30:45" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("2025-01-15T14:30:45Z");
         });
 
-        test("returns literal for v: getFunc", () => {
-            const item = new DateFormItem({ id: "d1", type: "date", get: "v:custom-date" });
+        test("returns literal for v: getFunc", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date", get: "v:custom-date" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("custom-date");
         });
 
-        test("formats date with moment when template has no mustache expressions", () => {
-            const item = new DateFormItem({ id: "d1", type: "date", get: "t:L", init: "v:2025-01-15" });
+        test("formats date with moment when template has no mustache expressions", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date", get: "t:L", init: "v:2025-01-15" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("01/15/2025");
         });
 
-        test("formats time with moment when template has no mustache expressions", () => {
-            const item = new DateFormItem({ id: "d1", type: "time", get: "t:LTS", init: "v:2025-01-15T14:30:45" });
+        test("formats time with moment when template has no mustache expressions", async () => {
+            const item = new DateFormItem({ id: "d1", type: "time", get: "t:LTS", init: "v:2025-01-15T14:30:45" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("2:30:45 PM");
         });
 
-        test("delegates to Mustache when template contains mustache expressions", () => {
-            const item = new DateFormItem({ id: "d1", type: "date", get: "t:{{label}}", init: "v:2025-01-15" });
+        test("delegates to Mustache when template contains mustache expressions", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date", get: "t:{{label}}", init: "v:2025-01-15" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({ label: "Jan 15" })).toBe("Jan 15");
         });
 
-        test("delegates to Mustache for mixed mustache and text", () => {
-            const item = new DateFormItem({ id: "d1", type: "date", get: "t:Date: {{label}}", init: "v:2025-01-15" });
+        test("delegates to Mustache for mixed mustache and text", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date", get: "t:Date: {{label}}", init: "v:2025-01-15" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({ label: "2025" })).toBe("Date: 2025");
         });
     });
@@ -133,33 +155,69 @@ describe("DateFormItem", () => {
     // ─── assignToForm ───
 
     describe("assignToForm", () => {
-        test("does nothing when no form display is configured", () => {
-            const item = new DateFormItem({ id: "d1", type: "date" });
+        test("does nothing when no form display is configured", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date" }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("does not throw for date type with form", () => {
+        test("does not throw for date type with form", async () => {
             const item = new DateFormItem({
                 id: "d1", type: "date",
                 form: { title: "Pick a date" },
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("does not throw for time type with form", () => {
+        test("does not throw for time type with form", async () => {
             const item = new DateFormItem({
                 id: "d1", type: "time",
                 form: { title: "Pick a time" },
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("does not throw for dateTime type with form", () => {
+        test("does not throw for dateTime type with form", async () => {
             const item = new DateFormItem({
                 id: "d1", type: "dateTime",
                 form: { title: "Pick date and time" },
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
+        });
+    });
+
+    // ─── initialize ───
+
+    describe("initialize", () => {
+        test("value is undefined before initialize", () => {
+            const item = new DateFormItem({ id: "d1", type: "date", init: "v:2025-01-15" }, mockFunctionProcessor);
+            expect(item.value).toBeUndefined();
+        });
+
+        test("resolves ref: init via executeRefFunction", async () => {
+            const refDate = new Date(2025, 5, 1);
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce(refDate);
+            const item = new DateFormItem({ id: "d1", type: "date", init: "ref:getDate" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("getDate");
+            expect(item.value).toBe(refDate);
+        });
+
+        test("resolves ref: with path via executeRefFunction", async () => {
+            const refDate = new Date(2024, 0, 1);
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce(refDate);
+            const item = new DateFormItem({ id: "d1", type: "date", init: "ref:/helpers.md:getDate" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("/helpers.md:getDate");
+            expect(item.value).toBe(refDate);
+        });
+
+        test("throws for unsupported init prefix", async () => {
+            const item = new DateFormItem({ id: "d1", type: "date", init: "x:bad" as any }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Unsupported init function");
         });
     });
 });

--- a/src/tests/dropdownFormItem.test.ts
+++ b/src/tests/dropdownFormItem.test.ts
@@ -13,6 +13,17 @@ jest.mock("src/ui/settingsExtension", () => {
     return { ExtendedSetting: jest.fn().mockImplementation(() => ({ ...mock })) };
 });
 
+const mockFunctionProcessor = {
+    renderMustacheTemplate: jest.fn(),
+    executeFunction: jest.fn().mockImplementation((funcText: string) => {
+        const func = eval(`(${funcText})`);
+        return func();
+    }),
+    executeFunctionWithParam: jest.fn(),
+    executeRefFunction: jest.fn(),
+    executeRefFunctionWithParam: jest.fn(),
+} as any;
+
 describe("DropdownFormItem", () => {
 
     const twoOptions = 'v:[{"k":"a","v":"Alpha"},{"k":"b","v":"Beta"}]' as const;
@@ -21,41 +32,44 @@ describe("DropdownFormItem", () => {
     // ─── constructor ───
 
     describe("constructor", () => {
-        test("parses v: JSON init and selects first option by default", () => {
-            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: twoOptions });
-            expect(item.value).toEqual([{ k: "a", v: "Alpha" }]);
+        test("parses v: JSON init and selects first option by default", async () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: twoOptions }, mockFunctionProcessor);
+            await item.initialize();
+            expect(item.value).toEqual([{ k: "a", v: "Alpha" }, { k: "b", v: "Beta" }]);
         });
 
-        test("selects option marked with s:true", () => {
-            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: withSelected });
-            expect(item.value).toEqual([{ k: "b", v: "Beta" }]);
+        test("selects option marked with s:true", async () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: withSelected }, mockFunctionProcessor);
+            await item.initialize();
+            expect(item.value).toEqual([{ k: "a", v: "Alpha" }, { k: "b", v: "Beta", s: true }]);
         });
 
-        test("evaluates f: init function", () => {
+        test("evaluates f: init function", async () => {
             const item = new DropdownFormItem({
                 id: "dd1", type: "dropdown",
                 init: 'f:() => [{"k":"x","v":"X-ray"}]',
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toEqual([{ k: "x", v: "X-ray" }]);
         });
 
-        test("throws when no init is provided", () => {
-            expect(() => new DropdownFormItem({ id: "dd1", type: "dropdown" }))
-                .toThrow("Default value is not supported");
+        test("throws when no init is provided", async () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown" }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Default value is not supported");
         });
 
-        test("throws for empty array init", () => {
-            expect(() => new DropdownFormItem({ id: "dd1", type: "dropdown", init: "v:[]" }))
-                .toThrow("Init value can't be empty");
+        test("throws for empty array init", async () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: "v:[]" }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Init value can't be empty");
         });
 
         test("throws for unsupported type", () => {
-            expect(() => new DropdownFormItem({ id: "dd1", type: "text" as any, init: twoOptions }))
+            expect(() => new DropdownFormItem({ id: "dd1", type: "text" as any, init: twoOptions }, mockFunctionProcessor))
                 .toThrow("Unsupported type");
         });
 
         test("sets id and type correctly", () => {
-            const item = new DropdownFormItem({ id: "myDd", type: "dropdown", init: twoOptions });
+            const item = new DropdownFormItem({ id: "myDd", type: "dropdown", init: twoOptions }, mockFunctionProcessor);
             expect(item.id).toBe("myDd");
             expect(item.type).toBe("dropdown");
         });
@@ -64,34 +78,39 @@ describe("DropdownFormItem", () => {
     // ─── get ───
 
     describe("get", () => {
-        test("returns selected option value when no getFunc", () => {
-            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: twoOptions });
+        test("returns selected option value when no getFunc", async () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: twoOptions }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("Alpha");
         });
 
-        test("returns selected value when s:true option", () => {
-            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: withSelected });
-            expect(item.get({})).toBe("Beta");
+        test("returns selected value when s:true option", async () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: withSelected }, mockFunctionProcessor);
+            await item.initialize();
+            expect(item.get({})).toBe("Alpha");
         });
 
-        test("returns literal for v: getFunc", () => {
+        test("returns literal for v: getFunc", async () => {
             const item = new DropdownFormItem({
                 id: "dd1", type: "dropdown", init: twoOptions, get: "v:override",
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("override");
         });
 
-        test("invokes arrow function for f: getFunc", () => {
+        test("invokes arrow function for f: getFunc", async () => {
             const item = new DropdownFormItem({
                 id: "dd1", type: "dropdown", init: twoOptions, get: "f:(view) => view.label",
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({ label: "from-view" })).toBe("from-view");
         });
 
-        test("invokes regular function for f: getFunc", () => {
+        test("invokes regular function for f: getFunc", async () => {
             const item = new DropdownFormItem({
                 id: "dd1", type: "dropdown", init: twoOptions, get: "f:function(view) { return view.label; }",
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({ label: "func-result" })).toBe("func-result");
         });
     });
@@ -99,17 +118,51 @@ describe("DropdownFormItem", () => {
     // ─── assignToForm ───
 
     describe("assignToForm", () => {
-        test("does nothing when no form display is configured", () => {
-            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: twoOptions });
+        test("does nothing when no form display is configured", async () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: twoOptions }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("does not throw when form display is configured", () => {
+        test("does not throw when form display is configured", async () => {
             const item = new DropdownFormItem({
                 id: "dd1", type: "dropdown", init: twoOptions,
                 form: { title: "Pick one" },
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
+        });
+    });
+
+    // ─── initialize ───
+
+    describe("initialize", () => {
+        test("value is undefined before initialize", () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: twoOptions }, mockFunctionProcessor);
+            expect(item.value).toBeUndefined();
+        });
+
+        test("resolves ref: init via executeRefFunction", async () => {
+            const refOptions = [{k: "r", v: "Ref"}];
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce(refOptions);
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: "ref:getOptions" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("getOptions");
+            expect(item.value).toEqual(refOptions);
+        });
+
+        test("resolves ref: with path via executeRefFunction", async () => {
+            const refOptions = [{k: "a", v: "Alpha"}, {k: "b", v: "Beta"}];
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce(refOptions);
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: "ref:/data.md:getOptions" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("/data.md:getOptions");
+            expect(item.value).toEqual(refOptions);
+        });
+
+        test("throws for unsupported init prefix", async () => {
+            const item = new DropdownFormItem({ id: "dd1", type: "dropdown", init: "x:bad" as any }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Unsupported init function");
         });
     });
 });

--- a/src/tests/fileFormItem.test.ts
+++ b/src/tests/fileFormItem.test.ts
@@ -13,55 +13,78 @@ jest.mock("src/ui/settingsExtension", () => {
     return { ExtendedSetting: jest.fn().mockImplementation(() => ({ ...mock })) };
 });
 
+const mockFunctionProcessor = {
+    renderMustacheTemplate: jest.fn(),
+    executeFunction: jest.fn(),
+    executeFunctionWithParam: jest.fn(),
+    executeRefFunction: jest.fn(),
+    executeRefFunctionWithParam: jest.fn(),
+} as any;
+
 describe("FileNameFormItem", () => {
 
     describe("constructor", () => {
         test("has id 'file-name'", () => {
-            const item = new FileNameFormItem();
+            const item = new FileNameFormItem(mockFunctionProcessor);
             expect(item.id).toBe("file-name");
         });
 
         test("has type 'text'", () => {
-            const item = new FileNameFormItem();
+            const item = new FileNameFormItem(mockFunctionProcessor);
             expect(item.type).toBe("text");
         });
 
-        test("defaults to empty string value", () => {
-            const item = new FileNameFormItem();
+        test("defaults to empty string value", async () => {
+            const item = new FileNameFormItem(mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe("");
         });
 
-        test("without getFunc, assignToForm renders a form", () => {
-            const item = new FileNameFormItem();
+        test("without getFunc, assignToForm renders a form", async () => {
+            const item = new FileNameFormItem(mockFunctionProcessor);
+            await item.initialize();
             // assignToForm should delegate to assignToFormImpl (form display is set)
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("with getFunc, assignToForm is a no-op", () => {
-            const item = new FileNameFormItem("v:hardcoded");
+        test("with getFunc, assignToForm is a no-op", async () => {
+            const item = new FileNameFormItem(mockFunctionProcessor, "v:hardcoded");
+            await item.initialize();
             // No form display → assignToForm does nothing
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
     });
 
     describe("get", () => {
-        test("returns normalized value when no getFunc", () => {
-            const item = new FileNameFormItem();
+        test("returns normalized value when no getFunc", async () => {
+            const item = new FileNameFormItem(mockFunctionProcessor);
+            await item.initialize();
             item.value = "my\\note";
             const result = item.get({});
             expect(result).toBe("my/note");
         });
 
-        test("returns normalized literal for v: getFunc", () => {
-            const item = new FileNameFormItem("v:some\\path");
+        test("returns normalized literal for v: getFunc", async () => {
+            const item = new FileNameFormItem(mockFunctionProcessor, "v:some\\path");
+            await item.initialize();
             const result = item.get({});
             expect(result).toBe("some/path");
         });
 
-        test("normalizes trailing slashes", () => {
-            const item = new FileNameFormItem("v:folder/name/");
+        test("normalizes trailing slashes", async () => {
+            const item = new FileNameFormItem(mockFunctionProcessor, "v:folder/name/");
+            await item.initialize();
             const result = item.get({});
             expect(result).toBe("folder/name");
+        });
+    });
+
+    // ─── initialize ───
+
+    describe("initialize", () => {
+        test("value is undefined before initialize", () => {
+            const item = new FileNameFormItem(mockFunctionProcessor);
+            expect(item.value).toBeUndefined();
         });
     });
 });
@@ -70,43 +93,57 @@ describe("FileLocationFormItem", () => {
 
     describe("constructor", () => {
         test("has id 'file-location'", () => {
-            const item = new FileLocationFormItem();
+            const item = new FileLocationFormItem(mockFunctionProcessor);
             expect(item.id).toBe("file-location");
         });
 
         test("has type 'text'", () => {
-            const item = new FileLocationFormItem();
+            const item = new FileLocationFormItem(mockFunctionProcessor);
             expect(item.type).toBe("text");
         });
 
-        test("defaults to empty string value", () => {
-            const item = new FileLocationFormItem();
+        test("defaults to empty string value", async () => {
+            const item = new FileLocationFormItem(mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe("");
         });
 
-        test("without getFunc, assignToForm renders a form", () => {
-            const item = new FileLocationFormItem();
+        test("without getFunc, assignToForm renders a form", async () => {
+            const item = new FileLocationFormItem(mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("with getFunc, assignToForm is a no-op", () => {
-            const item = new FileLocationFormItem("v:/notes");
+        test("with getFunc, assignToForm is a no-op", async () => {
+            const item = new FileLocationFormItem(mockFunctionProcessor, "v:/notes");
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
     });
 
     describe("get", () => {
-        test("returns normalized value when no getFunc", () => {
-            const item = new FileLocationFormItem();
+        test("returns normalized value when no getFunc", async () => {
+            const item = new FileLocationFormItem(mockFunctionProcessor);
+            await item.initialize();
             item.value = "path\\to\\folder";
             const result = item.get({});
             expect(result).toBe("path/to/folder");
         });
 
-        test("returns normalized literal for v: getFunc", () => {
-            const item = new FileLocationFormItem("v:my\\folder");
+        test("returns normalized literal for v: getFunc", async () => {
+            const item = new FileLocationFormItem(mockFunctionProcessor, "v:my\\folder");
+            await item.initialize();
             const result = item.get({});
             expect(result).toBe("my/folder");
+        });
+    });
+
+    // ─── initialize ───
+
+    describe("initialize", () => {
+        test("value is undefined before initialize", () => {
+            const item = new FileLocationFormItem(mockFunctionProcessor);
+            expect(item.value).toBeUndefined();
         });
     });
 });

--- a/src/tests/formItemFunctionProcessor.test.ts
+++ b/src/tests/formItemFunctionProcessor.test.ts
@@ -1,0 +1,297 @@
+import { FormItemFunctionProcessor } from "../form/formItemFunctionProcessor";
+import { TFile } from "obsidian";
+
+// ── helpers ──
+
+function createMockFile(path: string): TFile {
+    const file = new TFile();
+    file.path = path;
+    return file;
+}
+
+function createMockApp(overrides: {
+    cachedRead?: jest.Mock;
+    getFileByPath?: jest.Mock;
+} = {}) {
+    return {
+        vault: {
+            cachedRead: overrides.cachedRead ?? jest.fn(),
+            getFileByPath: overrides.getFileByPath ?? jest.fn(),
+        },
+        metadataCache: {
+            getFileCache: jest.fn(),
+        },
+    } as any;
+}
+
+function createProcessor(overrides: {
+    fileContent?: string;
+    externalFile?: TFile | null;
+    templateFile?: TFile;
+    templatePropertyName?: string;
+} = {}) {
+    const templateFile = overrides.templateFile ?? createMockFile("templates/my-template.md");
+    const externalFile = overrides.externalFile;
+
+    const cachedRead = jest.fn().mockResolvedValue(overrides.fileContent ?? "");
+    const getFileByPath = jest.fn().mockReturnValue(externalFile ?? null);
+
+    const app = createMockApp({ cachedRead, getFileByPath });
+    const template = { file: templateFile, label: "My Template" };
+    const settings = {
+        templatesFolderLocation: "templates",
+        templatePropertyName: overrides.templatePropertyName ?? "note-from-form",
+        defaultOutputDir: "",
+    };
+
+    const processor = new FormItemFunctionProcessor(template, app, settings);
+    return { processor, cachedRead, getFileByPath };
+}
+
+function codeBlock(tag: string, funcName: string, body: string): string {
+    return "```js:" + tag + ":" + funcName + "\n" + body + "\n```";
+}
+
+// ── tests ──
+
+describe("FormItemFunctionProcessor", () => {
+
+    // ─── renderMustacheTemplate ───
+
+    describe("renderMustacheTemplate", () => {
+        test("renders template with view data", () => {
+            const { processor } = createProcessor();
+            const result = processor.renderMustacheTemplate("Hello {{name}}", { name: "World" });
+            expect(result).toBe("Hello World");
+        });
+
+        test("returns template as-is when no placeholders", () => {
+            const { processor } = createProcessor();
+            const result = processor.renderMustacheTemplate("plain text", {});
+            expect(result).toBe("plain text");
+        });
+
+        test("does not escape HTML", () => {
+            const { processor } = createProcessor();
+            const result = processor.renderMustacheTemplate("{{val}}", { val: "<b>bold</b>" });
+            expect(result).toBe("<b>bold</b>");
+        });
+    });
+
+    // ─── executeFunction ───
+
+    describe("executeFunction", () => {
+        test("evaluates arrow function", () => {
+            const { processor } = createProcessor();
+            const result = processor.executeFunction<number>("() => 42");
+            expect(result).toBe(42);
+        });
+
+        test("evaluates function expression", () => {
+            const { processor } = createProcessor();
+            const result = processor.executeFunction<string>("function() { return 'hello'; }");
+            expect(result).toBe("hello");
+        });
+
+        test("throws for invalid function text", () => {
+            const { processor } = createProcessor();
+            expect(() => processor.executeFunction("not a function")).toThrow();
+        });
+    });
+
+    // ─── executeFunctionWithParam ───
+
+    describe("executeFunctionWithParam", () => {
+        test("passes arguments to arrow function", () => {
+            const { processor } = createProcessor();
+            const result = processor.executeFunctionWithParam<string, [Record<string, any>]>(
+                "(view) => view.name", { name: "test" }
+            );
+            expect(result).toBe("test");
+        });
+
+        test("passes arguments to function expression", () => {
+            const { processor } = createProcessor();
+            const result = processor.executeFunctionWithParam<number, [number, number]>(
+                "function(a, b) { return a + b; }", 3, 4
+            );
+            expect(result).toBe(7);
+        });
+    });
+
+    // ─── executeRefFunction ───
+
+    describe("executeRefFunction", () => {
+        test("reads function from current template file by name", async () => {
+            const templateFile = createMockFile("templates/my-template.md");
+            const body = "() => 'from-template'";
+            const fileContent = codeBlock("note-from-form", "myInit", body);
+
+            const { processor, cachedRead } = createProcessor({
+                templateFile,
+                fileContent,
+            });
+
+            const result = await processor.executeRefFunction<string>("myInit");
+            expect(cachedRead).toHaveBeenCalledWith(templateFile);
+            expect(result).toBe("from-template");
+        });
+
+        test("reads function from external file by path:name", async () => {
+            const externalFile = createMockFile("utils/helpers.md");
+            const body = "() => 99";
+            const fileContent = codeBlock("note-from-form", "getNum", body);
+
+            const { processor, cachedRead, getFileByPath } = createProcessor({
+                externalFile,
+                fileContent,
+            });
+
+            const result = await processor.executeRefFunction<number>("utils/helpers.md:getNum");
+            expect(getFileByPath).toHaveBeenCalledWith("utils/helpers.md");
+            expect(cachedRead).toHaveBeenCalledWith(externalFile);
+            expect(result).toBe(99);
+        });
+
+        test("throws when external file is not found", async () => {
+            const { processor } = createProcessor({ externalFile: null, fileContent: "" });
+            await expect(processor.executeRefFunction("missing/file.md:func"))
+                .rejects.toThrow("File not found for reference");
+        });
+
+        test("throws when function is not found in file", async () => {
+            const templateFile = createMockFile("templates/tpl.md");
+            const { processor } = createProcessor({
+                templateFile,
+                fileContent: "some content without code blocks",
+            });
+
+            await expect(processor.executeRefFunction("nonExistent"))
+                .rejects.toThrow("Function 'nonExistent' not found in file");
+        });
+
+        test("throws for invalid ref format with multiple colons", async () => {
+            const { processor } = createProcessor();
+            await expect(processor.executeRefFunction("a:b:c"))
+                .rejects.toThrow("Invalid reference format");
+        });
+    });
+
+    // ─── executeRefFunctionWithParam ───
+
+    describe("executeRefFunctionWithParam", () => {
+        test("passes arguments to referenced function", async () => {
+            const templateFile = createMockFile("templates/tpl.md");
+            const body = "(view) => view.x + 1";
+            const fileContent = codeBlock("note-from-form", "compute", body);
+
+            const { processor } = createProcessor({
+                templateFile,
+                fileContent,
+            });
+
+            const result = await processor.executeRefFunctionWithParam<number, [Record<string, any>]>(
+                "compute", { x: 10 }
+            );
+            expect(result).toBe(11);
+        });
+    });
+
+    // ─── getFunctionText (via executeRefFunction) ───
+
+    describe("getFunctionText regex matching", () => {
+        test("matches code block with custom templatePropertyName", async () => {
+            const templateFile = createMockFile("tpl.md");
+            const body = "() => 'custom'";
+            const fileContent = codeBlock("my-form", "init", body);
+
+            const { processor } = createProcessor({
+                templateFile,
+                templatePropertyName: "my-form",
+                fileContent,
+            });
+
+            const result = await processor.executeRefFunction<string>("init");
+            expect(result).toBe("custom");
+        });
+
+        test("ignores code blocks with wrong tag", async () => {
+            const templateFile = createMockFile("tpl.md");
+            const fileContent = codeBlock("other-plugin", "init", "() => 'wrong'");
+
+            const { processor } = createProcessor({
+                templateFile,
+                fileContent,
+            });
+
+            await expect(processor.executeRefFunction("init"))
+                .rejects.toThrow("Function 'init' not found in file");
+        });
+
+        test("ignores code blocks with wrong function name", async () => {
+            const templateFile = createMockFile("tpl.md");
+            const fileContent = codeBlock("note-from-form", "other", "() => 'wrong'");
+
+            const { processor } = createProcessor({
+                templateFile,
+                fileContent,
+            });
+
+            await expect(processor.executeRefFunction("myFunc"))
+                .rejects.toThrow("Function 'myFunc' not found in file");
+        });
+
+        test("extracts multiline function body", async () => {
+            const templateFile = createMockFile("tpl.md");
+            const body = "function() {\n    const x = 1;\n    return x + 1;\n}";
+            const fileContent = codeBlock("note-from-form", "calc", body);
+
+            const { processor } = createProcessor({
+                templateFile,
+                fileContent,
+            });
+
+            const result = await processor.executeRefFunction<number>("calc");
+            expect(result).toBe(2);
+        });
+
+        test("matches correct block among multiple blocks", async () => {
+            const templateFile = createMockFile("tpl.md");
+            const fileContent = [
+                codeBlock("note-from-form", "first", "() => 'one'"),
+                "",
+                codeBlock("note-from-form", "second", "() => 'two'"),
+            ].join("\n");
+
+            const { processor } = createProcessor({
+                templateFile,
+                fileContent,
+            });
+
+            const result1 = await processor.executeRefFunction<string>("first");
+            expect(result1).toBe("one");
+        });
+
+        test("matches block surrounded by other markdown", async () => {
+            const templateFile = createMockFile("tpl.md");
+            const body = "() => true";
+            const fileContent = [
+                "# My Template",
+                "",
+                "Some description here.",
+                "",
+                codeBlock("note-from-form", "isActive", body),
+                "",
+                "More text after.",
+            ].join("\n");
+
+            const { processor } = createProcessor({
+                templateFile,
+                fileContent,
+            });
+
+            const result = await processor.executeRefFunction<boolean>("isActive");
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/src/tests/formItemManager.test.ts
+++ b/src/tests/formItemManager.test.ts
@@ -7,12 +7,21 @@ import { CheckboxFormItem } from "../form/checkboxFormItem";
 import { DropdownFormItem } from "../form/dropdownFormItem";
 import { NoteTemplate } from "../template/templateTypes";
 import { NoteFromFormPluginSettings } from "../pluginSettings";
+import { FormItemFunctionProcessor } from "../form/formItemFunctionProcessor";
 
 const mockSettings: NoteFromFormPluginSettings = {
     templatesFolderLocation: "/",
     templatePropertyName: "note-from-form",
     defaultOutputDir: "/",
 };
+
+const mockFunctionProcessor = {
+    renderMustacheTemplate: jest.fn((t: string, v: any) => t),
+    executeFunction: jest.fn((f: string) => eval(`(${f})()`)),
+    executeFunctionWithParam: jest.fn((f: string, ...args: any[]) => eval(`(${f})`).apply(null, args)),
+    executeRefFunction: jest.fn(),
+    executeRefFunctionWithParam: jest.fn(),
+} as unknown as FormItemFunctionProcessor;
 
 jest.mock("moment", () => {
     const fn = (date: any) => ({
@@ -41,95 +50,95 @@ jest.mock("src/ui/dateTimeComponent", () => ({
 describe("FormItemsManager", () => {
 
     describe("getFormItems", () => {
-        test("always creates FileNameFormItem and FileLocationFormItem", () => {
+        test("always creates FileNameFormItem and FileLocationFormItem", async () => {
             const template: NoteTemplate = {};
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
 
             expect(items.length).toBeGreaterThanOrEqual(2);
             expect(items[0]).toBeInstanceOf(FileNameFormItem);
             expect(items[1]).toBeInstanceOf(FileLocationFormItem);
         });
 
-        test("passes file-name getFunc to FileNameFormItem", () => {
+        test("passes file-name getFunc to FileNameFormItem", async () => {
             const template: NoteTemplate = { "file-name": "v:MyNote" };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[0].get({})).toBe("MyNote");
         });
 
-        test("passes file-location getFunc to FileLocationFormItem", () => {
+        test("passes file-location getFunc to FileLocationFormItem", async () => {
             const template: NoteTemplate = { "file-location": "v:notes/folder" };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[1].get({})).toBe("notes/folder");
         });
 
-        test("creates TextFormItem for text type", () => {
+        test("creates TextFormItem for text type", async () => {
             const template: NoteTemplate = {
                 "form-items": [{ id: "t", type: "text" }],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[2]).toBeInstanceOf(TextFormItem);
         });
 
-        test("creates TextFormItem for textArea type", () => {
+        test("creates TextFormItem for textArea type", async () => {
             const template: NoteTemplate = {
                 "form-items": [{ id: "t", type: "textArea" }],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[2]).toBeInstanceOf(TextFormItem);
         });
 
-        test("creates NumberFormItem for number type", () => {
+        test("creates NumberFormItem for number type", async () => {
             const template: NoteTemplate = {
                 "form-items": [{ id: "n", type: "number" }],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[2]).toBeInstanceOf(NumberFormItem);
         });
 
-        test("creates DateTimeFormItem for date type", () => {
+        test("creates DateTimeFormItem for date type", async () => {
             const template: NoteTemplate = {
                 "form-items": [{ id: "d", type: "date" }],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[2]).toBeInstanceOf(DateTimeFormItem);
         });
 
-        test("creates DateTimeFormItem for time type", () => {
+        test("creates DateTimeFormItem for time type", async () => {
             const template: NoteTemplate = {
                 "form-items": [{ id: "d", type: "time" }],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[2]).toBeInstanceOf(DateTimeFormItem);
         });
 
-        test("creates DateTimeFormItem for dateTime type", () => {
+        test("creates DateTimeFormItem for dateTime type", async () => {
             const template: NoteTemplate = {
                 "form-items": [{ id: "d", type: "dateTime" }],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[2]).toBeInstanceOf(DateTimeFormItem);
         });
 
-        test("creates CheckboxFormItem for checkbox type", () => {
+        test("creates CheckboxFormItem for checkbox type", async () => {
             const template: NoteTemplate = {
                 "form-items": [{ id: "c", type: "checkbox" }],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[2]).toBeInstanceOf(CheckboxFormItem);
         });
 
-        test("creates DropdownFormItem for dropdown type", () => {
+        test("creates DropdownFormItem for dropdown type", async () => {
             const template: NoteTemplate = {
                 "form-items": [{
                     id: "dd", type: "dropdown",
                     init: 'v:[{"k":"a","v":"A"}]',
                 }],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items[2]).toBeInstanceOf(DropdownFormItem);
         });
 
-        test("handles multiple form items", () => {
+        test("handles multiple form items", async () => {
             const template: NoteTemplate = {
                 "form-items": [
                     { id: "t", type: "text" },
@@ -137,42 +146,42 @@ describe("FormItemsManager", () => {
                     { id: "c", type: "checkbox" },
                 ],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             // 2 file items + 3 form items
             expect(items.length).toBe(5);
         });
 
-        test("returns only file items when form-items is undefined", () => {
+        test("returns only file items when form-items is undefined", async () => {
             const template: NoteTemplate = {};
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items.length).toBe(2);
         });
 
-        test("returns only file items when form-items is empty", () => {
+        test("returns only file items when form-items is empty", async () => {
             const template: NoteTemplate = { "form-items": [] };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             expect(items.length).toBe(2);
         });
     });
 
     describe("getViewModel", () => {
-        test("returns empty result for file-only items with no values", () => {
+        test("returns empty result for file-only items with no values", async () => {
             const template: NoteTemplate = {};
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             // file items have no user input, default get returns value (empty string)
             const vm = FormItemsManager.getViewModel(items);
             expect(vm["file-name"]).toBeDefined();
             expect(vm["file-location"]).toBeDefined();
         });
 
-        test("includes form item values in view model", () => {
+        test("includes form item values in view model", async () => {
             const template: NoteTemplate = {
                 "form-items": [
                     { id: "t1", type: "text" },
                     { id: "t2", type: "text" },
                 ],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             items[2].value = "hello";
             items[3].value = "world";
 
@@ -181,18 +190,18 @@ describe("FormItemsManager", () => {
             expect(vm["t2"]).toBe("world");
         });
 
-        test("resolves value-string get functions", () => {
+        test("resolves value-string get functions", async () => {
             const template: NoteTemplate = {
                 "form-items": [
                     { id: "t", type: "text", get: "v:static-value" },
                 ],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             const vm = FormItemsManager.getViewModel(items);
             expect(vm["t"]).toBe("static-value");
         });
 
-        test("excludes file-name and file-location from intermediate view but includes in result", () => {
+        test("excludes file-name and file-location from intermediate view but includes in result", async () => {
             const template: NoteTemplate = {
                 "file-name": "v:MyNote",
                 "file-location": "v:notes",
@@ -200,7 +209,7 @@ describe("FormItemsManager", () => {
                     { id: "title", type: "text" },
                 ],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             items[2].value = "Test Title";
 
             const vm = FormItemsManager.getViewModel(items);
@@ -209,14 +218,14 @@ describe("FormItemsManager", () => {
             expect(vm["file-location"]).toBe("notes");
         });
 
-        test("resolves file-name after form items", () => {
+        test("resolves file-name after form items", async () => {
             const template: NoteTemplate = {
                 "file-name": "v:NoteName",
                 "form-items": [
                     { id: "t", type: "text" },
                 ],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             items[2].value = "value";
 
             const vm = FormItemsManager.getViewModel(items);
@@ -225,33 +234,33 @@ describe("FormItemsManager", () => {
             expect(vm["t"]).toBe("value");
         });
 
-        test("handles number form item values", () => {
+        test("handles number form item values", async () => {
             const template: NoteTemplate = {
                 "form-items": [
                     { id: "n", type: "number" },
                 ],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             items[2].value = 42;
 
             const vm = FormItemsManager.getViewModel(items);
             expect(vm["n"]).toBe("42");
         });
 
-        test("handles checkbox form item values", () => {
+        test("handles checkbox form item values", async () => {
             const template: NoteTemplate = {
                 "form-items": [
                     { id: "c", type: "checkbox" },
                 ],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             items[2].value = true;
 
             const vm = FormItemsManager.getViewModel(items);
             expect(vm["c"]).toBeDefined();
         });
 
-        test("handles mixed form item types", () => {
+        test("handles mixed form item types", async () => {
             const template: NoteTemplate = {
                 "file-name": "v:TestNote",
                 "form-items": [
@@ -260,7 +269,7 @@ describe("FormItemsManager", () => {
                     { id: "c", type: "checkbox" },
                 ],
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             items[2].value = "text-val";
             items[3].value = 7;
             items[4].value = true;
@@ -272,11 +281,11 @@ describe("FormItemsManager", () => {
             expect(vm["file-name"]).toBe("TestNote");
         });
 
-        test("returns only file items in view model when no form items", () => {
+        test("returns only file items in view model when no form items", async () => {
             const template: NoteTemplate = {
                 "file-name": "v:OnlyFile",
             };
-            const items = FormItemsManager.getFormItems(template, mockSettings);
+            const items = await FormItemsManager.getFormItems(template, mockFunctionProcessor, mockSettings);
             const vm = FormItemsManager.getViewModel(items);
 
             expect(Object.keys(vm)).toEqual(

--- a/src/tests/inputFormModal.test.ts
+++ b/src/tests/inputFormModal.test.ts
@@ -54,6 +54,7 @@ function createMockFormItem(id: string): FormItem {
         value: "",
         assignToForm: jest.fn(),
         get: jest.fn().mockReturnValue(""),
+        initialize: jest.fn().mockResolvedValue(undefined),
     };
 }
 

--- a/src/tests/numberFormItem.test.ts
+++ b/src/tests/numberFormItem.test.ts
@@ -13,48 +13,64 @@ jest.mock("src/ui/settingsExtension", () => {
     return { ExtendedSetting: jest.fn().mockImplementation(() => ({ ...mock })) };
 });
 
+const mockFunctionProcessor = {
+    renderMustacheTemplate: jest.fn(),
+    executeFunction: jest.fn().mockImplementation((funcText: string) => {
+        const func = eval(`(${funcText})`);
+        return func();
+    }),
+    executeFunctionWithParam: jest.fn(),
+    executeRefFunction: jest.fn(),
+    executeRefFunctionWithParam: jest.fn(),
+} as any;
+
 describe("NumberFormItem", () => {
 
     // ─── constructor ───
 
     describe("constructor", () => {
-        test("defaults to 0 when no init provided", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number" });
+        test("defaults to 0 when no init provided", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(0);
         });
 
-        test("parses v: numeric init", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:42" });
+        test("parses v: numeric init", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:42" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(42);
         });
 
-        test("parses v: negative number", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:-7" });
+        test("parses v: negative number", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:-7" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(-7);
         });
 
-        test("parses v: float", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:3.14" });
+        test("parses v: float", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:3.14" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBeCloseTo(3.14);
         });
 
-        test("throws for v: non-numeric init", () => {
-            expect(() => new NumberFormItem({ id: "n1", type: "number", init: "v:abc" }))
-                .toThrow("Invalid number init value");
+        test("throws for v: non-numeric init", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:abc" }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Invalid number init value");
         });
 
-        test("evaluates f: init function", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number", init: "f:() => 99" });
+        test("evaluates f: init function", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "f:() => 99" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe(99);
         });
 
         test("throws for unsupported type", () => {
-            expect(() => new NumberFormItem({ id: "n1", type: "text" as any }))
+            expect(() => new NumberFormItem({ id: "n1", type: "text" as any }, mockFunctionProcessor))
                 .toThrow("Unsupported type");
         });
 
         test("sets id and type correctly", () => {
-            const item = new NumberFormItem({ id: "myNum", type: "number" });
+            const item = new NumberFormItem({ id: "myNum", type: "number" }, mockFunctionProcessor);
             expect(item.id).toBe("myNum");
             expect(item.type).toBe("number");
         });
@@ -63,18 +79,21 @@ describe("NumberFormItem", () => {
     // ─── get ───
 
     describe("get", () => {
-        test("returns stringified number when no getFunc", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:42" });
+        test("returns stringified number when no getFunc", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:42" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("42");
         });
 
-        test("returns '0' for default value", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number" });
+        test("returns '0' for default value", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("0");
         });
 
-        test("returns literal for v: getFunc", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number", get: "v:hundred" });
+        test("returns literal for v: getFunc", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", get: "v:hundred" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("hundred");
         });
     });
@@ -82,17 +101,49 @@ describe("NumberFormItem", () => {
     // ─── assignToForm ───
 
     describe("assignToForm", () => {
-        test("does nothing when no form display is configured", () => {
-            const item = new NumberFormItem({ id: "n1", type: "number" });
+        test("does nothing when no form display is configured", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number" }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("does not throw when form display is configured", () => {
+        test("does not throw when form display is configured", async () => {
             const item = new NumberFormItem({
                 id: "n1", type: "number",
                 form: { title: "Enter a number" },
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
+        });
+    });
+
+    // ─── initialize ───
+
+    describe("initialize", () => {
+        test("value is undefined before initialize", () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "v:42" }, mockFunctionProcessor);
+            expect(item.value).toBeUndefined();
+        });
+
+        test("resolves ref: init via executeRefFunction", async () => {
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce(77);
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "ref:getNumber" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("getNumber");
+            expect(item.value).toBe(77);
+        });
+
+        test("resolves ref: with path via executeRefFunction", async () => {
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce(123);
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "ref:/utils.md:getNumber" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("/utils.md:getNumber");
+            expect(item.value).toBe(123);
+        });
+
+        test("throws for unsupported init prefix", async () => {
+            const item = new NumberFormItem({ id: "n1", type: "number", init: "x:bad" as any }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Unsupported init function");
         });
     });
 });

--- a/src/tests/templateIndex.test.ts
+++ b/src/tests/templateIndex.test.ts
@@ -70,16 +70,18 @@ describe("TemplateIndex", () => {
             expect(processFrontMatter).not.toHaveBeenCalled();
         });
 
-        test("ignores file outside templates folder", () => {
+        test("ignores file outside templates folder", async () => {
             const settings = defaultSettings();
-            const processFrontMatter = jest.fn();
+            const processFrontMatter = jest.fn().mockImplementation(async (_file: any, fn: any) => fn({}));
             const app = createMockApp({ processFrontMatter });
             const index = createIndex(app, settings);
 
             const file = createFile('other/note.md');
             index.onVaultChange(file);
 
-            expect(processFrontMatter).not.toHaveBeenCalled();
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(index.getItems()).toHaveLength(0);
         });
 
         test("updates index for file inside templates folder", async () => {
@@ -128,16 +130,18 @@ describe("TemplateIndex", () => {
             expect(index.getItems()).toHaveLength(1);
         });
 
-        test("does not match folder with similar prefix", () => {
+        test("does not match folder with similar prefix", async () => {
             const settings = defaultSettings();
-            const processFrontMatter = jest.fn();
+            const processFrontMatter = jest.fn().mockImplementation(async (_file: any, fn: any) => fn({}));
             const app = createMockApp({ processFrontMatter });
             const index = createIndex(app, settings);
 
             const file = createFile('templates-other/note.md');
             index.onVaultChange(file);
 
-            expect(processFrontMatter).not.toHaveBeenCalled();
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(index.getItems()).toHaveLength(0);
         });
     });
 

--- a/src/tests/templateIndex.test.ts
+++ b/src/tests/templateIndex.test.ts
@@ -427,4 +427,70 @@ describe("TemplateIndex", () => {
             expect(onIndexChanged).not.toHaveBeenCalled();
         });
     });
+
+    // ─── isTemplateFile ───
+
+    describe("isTemplateFile", () => {
+        test("returns false when index is empty", () => {
+            const app = createMockApp();
+            const index = createIndex(app, defaultSettings());
+            const file = createFile('templates/note.md');
+
+            expect(index.isTemplateFile(file)).toBe(false);
+        });
+
+        test("returns true for an indexed template file", async () => {
+            const settings = defaultSettings();
+            const file = createFile('templates/note.md');
+            const folder = createFolder('templates', [file]);
+            const processFrontMatter = mockProcessFrontMatter({
+                'templates/note.md': { [TEMPLATE_PROPERTY_NAME]: true },
+            });
+            const app = createMockApp({
+                processFrontMatter,
+                getFolderByPath: jest.fn().mockReturnValue(folder),
+            });
+            const index = createIndex(app, settings);
+            await index.rebuild();
+
+            expect(index.isTemplateFile(file)).toBe(true);
+        });
+
+        test("returns false for a file not in the index", async () => {
+            const settings = defaultSettings();
+            const indexedFile = createFile('templates/note.md');
+            const otherFile = createFile('templates/other.md');
+            const folder = createFolder('templates', [indexedFile]);
+            const processFrontMatter = mockProcessFrontMatter({
+                'templates/note.md': { [TEMPLATE_PROPERTY_NAME]: true },
+            });
+            const app = createMockApp({
+                processFrontMatter,
+                getFolderByPath: jest.fn().mockReturnValue(folder),
+            });
+            const index = createIndex(app, settings);
+            await index.rebuild();
+
+            expect(index.isTemplateFile(otherFile)).toBe(false);
+        });
+
+        test("matches by file path", async () => {
+            const settings = defaultSettings();
+            const file = createFile('templates/note.md');
+            const folder = createFolder('templates', [file]);
+            const processFrontMatter = mockProcessFrontMatter({
+                'templates/note.md': { [TEMPLATE_PROPERTY_NAME]: true },
+            });
+            const app = createMockApp({
+                processFrontMatter,
+                getFolderByPath: jest.fn().mockReturnValue(folder),
+            });
+            const index = createIndex(app, settings);
+            await index.rebuild();
+
+            // Different TFile instance but same path
+            const samePathFile = createFile('templates/note.md');
+            expect(index.isTemplateFile(samePathFile)).toBe(true);
+        });
+    });
 });

--- a/src/tests/templateProcessor.test.ts
+++ b/src/tests/templateProcessor.test.ts
@@ -3,8 +3,17 @@ import { TemplateProcessor } from '../template/templateProcessor';
 import { NoteFromFormPluginSettings, TEMPLATE_PROPERTY_NAME } from '../pluginSettings';
 import { TemplateIndexItem } from '../template/templateIndex';
 import { FormItem } from '../form/formItem';
+import { FormItemFunctionProcessor } from '../form/formItemFunctionProcessor';
 
 // ── mocks ──
+
+const mockFunctionProcessor = {
+    renderMustacheTemplate: jest.fn((t: string, v: any) => t),
+    executeFunction: jest.fn((f: string) => eval(`(${f})()`)),
+    executeFunctionWithParam: jest.fn((f: string, ...args: any[]) => eval(`(${f})`).apply(null, args)),
+    executeRefFunction: jest.fn(),
+    executeRefFunctionWithParam: jest.fn(),
+} as unknown as FormItemFunctionProcessor;
 
 jest.mock("moment", () => {
     const fn = (date: any) => ({
@@ -247,7 +256,7 @@ describe("TemplateProcessor", () => {
             );
 
             const { FormItemsManager } = require("../form/formItemManager");
-            const formItems = FormItemsManager.getFormItems(template, defaultSettings());
+            const formItems = await FormItemsManager.getFormItems(template, mockFunctionProcessor, defaultSettings());
             formItems[2].value = "hello";
 
             const result = await callback(formItems, indexed);
@@ -282,7 +291,7 @@ describe("TemplateProcessor", () => {
             );
 
             const { FormItemsManager } = require("../form/formItemManager");
-            const formItems = FormItemsManager.getFormItems(template, defaultSettings());
+            const formItems = await FormItemsManager.getFormItems(template, mockFunctionProcessor, defaultSettings());
 
             const result = await callback(formItems, indexed);
 
@@ -310,7 +319,7 @@ describe("TemplateProcessor", () => {
             );
 
             const { FormItemsManager } = require("../form/formItemManager");
-            const formItems = FormItemsManager.getFormItems({}, defaultSettings());
+            const formItems = await FormItemsManager.getFormItems({}, mockFunctionProcessor, defaultSettings());
             formItems[0].value = "Note";
             formItems[1].value = "existing";
 
@@ -341,7 +350,7 @@ describe("TemplateProcessor", () => {
             );
 
             const { FormItemsManager } = require("../form/formItemManager");
-            const formItems = FormItemsManager.getFormItems({}, defaultSettings());
+            const formItems = await FormItemsManager.getFormItems({}, mockFunctionProcessor, defaultSettings());
             formItems[0].value = "Note";
             formItems[1].value = "out";
 
@@ -375,8 +384,9 @@ describe("TemplateProcessor", () => {
             );
 
             const { FormItemsManager } = require("../form/formItemManager");
-            const formItems = FormItemsManager.getFormItems(
+            const formItems = await FormItemsManager.getFormItems(
                 { "form-items": [{ id: "title", type: "text" }] },
+                mockFunctionProcessor,
                 defaultSettings(),
             );
             formItems[0].value = "Note";
@@ -410,8 +420,9 @@ describe("TemplateProcessor", () => {
             );
 
             const { FormItemsManager } = require("../form/formItemManager");
-            const formItems = FormItemsManager.getFormItems(
+            const formItems = await FormItemsManager.getFormItems(
                 { "form-items": [{ id: "content", type: "text" }] },
+                mockFunctionProcessor,
                 defaultSettings(),
             );
             formItems[0].value = "Note";

--- a/src/tests/templateProcessor.test.ts
+++ b/src/tests/templateProcessor.test.ts
@@ -561,6 +561,7 @@ describe("TemplateProcessor", () => {
                 value: "x",
                 assignToForm: jest.fn(),
                 get: () => { throw new Error("broken"); },
+                initialize: jest.fn().mockResolvedValue(undefined),
             };
 
             const result = await callback([badItem], indexed);

--- a/src/tests/templateProcessor.test.ts
+++ b/src/tests/templateProcessor.test.ts
@@ -362,6 +362,110 @@ describe("TemplateProcessor", () => {
             expect(capturedFrontmatters[0]).toHaveProperty("other", "keep");
         });
 
+        test("sanitizes new note by removing code blocks with template property name", async () => {
+            const folder = createFolder('out');
+            const getFolderByPath = jest.fn().mockReturnValue(folder);
+            const copy = jest.fn().mockImplementation(async (_src: TFile, newPath: string) => createFile(newPath));
+            const processFrontMatter = jest.fn().mockImplementation(async (file: TFile, fn: (fm: any) => void) => {
+                if (file.path === 'templates/note.md') {
+                    fn({ [TEMPLATE_PROPERTY_NAME]: {} });
+                } else {
+                    fn({});
+                }
+            });
+            let sanitizedContent: string | null = null;
+            let processCallCount = 0;
+            const process = jest.fn().mockImplementation(async (_file: TFile, cb: (content: string) => string) => {
+                processCallCount++;
+                if (processCallCount === 1) {
+                    // sanitizeNewNote call
+                    const input = [
+                        "# My Note",
+                        "",
+                        "Some content.",
+                        "",
+                        "```js:" + TEMPLATE_PROPERTY_NAME + ":myInit",
+                        "() => 'default'",
+                        "```",
+                        "",
+                        "More content.",
+                        "",
+                        "```js:" + TEMPLATE_PROPERTY_NAME + ":getTitle",
+                        "(view) => view.title",
+                        "```",
+                        "",
+                        "End of note.",
+                    ].join("\n");
+                    sanitizedContent = cb(input);
+                }
+            });
+
+            const { callback, indexed } = await setupAndGetCallback(
+                {},
+                { getFolderByPath, copy, processFrontMatter, process },
+            );
+
+            const { FormItemsManager } = require("../form/formItemManager");
+            const formItems = await FormItemsManager.getFormItems({}, mockFunctionProcessor, defaultSettings());
+            formItems[0].value = "Note";
+            formItems[1].value = "out";
+
+            await callback(formItems, indexed);
+
+            expect(sanitizedContent).not.toContain("```js:" + TEMPLATE_PROPERTY_NAME);
+            expect(sanitizedContent).toContain("# My Note");
+            expect(sanitizedContent).toContain("Some content.");
+            expect(sanitizedContent).toContain("More content.");
+            expect(sanitizedContent).toContain("End of note.");
+        });
+
+        test("does not remove code blocks with different tags", async () => {
+            const folder = createFolder('out');
+            const getFolderByPath = jest.fn().mockReturnValue(folder);
+            const copy = jest.fn().mockImplementation(async (_src: TFile, newPath: string) => createFile(newPath));
+            const processFrontMatter = jest.fn().mockImplementation(async (file: TFile, fn: (fm: any) => void) => {
+                if (file.path === 'templates/note.md') {
+                    fn({ [TEMPLATE_PROPERTY_NAME]: {} });
+                } else {
+                    fn({});
+                }
+            });
+            let sanitizedContent: string | null = null;
+            let processCallCount = 0;
+            const process = jest.fn().mockImplementation(async (_file: TFile, cb: (content: string) => string) => {
+                processCallCount++;
+                if (processCallCount === 1) {
+                    const input = [
+                        "# Note",
+                        "",
+                        "```js:other-plugin:func",
+                        "() => 42",
+                        "```",
+                        "",
+                        "```javascript",
+                        "const x = 1;",
+                        "```",
+                    ].join("\n");
+                    sanitizedContent = cb(input);
+                }
+            });
+
+            const { callback, indexed } = await setupAndGetCallback(
+                {},
+                { getFolderByPath, copy, processFrontMatter, process },
+            );
+
+            const { FormItemsManager } = require("../form/formItemManager");
+            const formItems = await FormItemsManager.getFormItems({}, mockFunctionProcessor, defaultSettings());
+            formItems[0].value = "Note";
+            formItems[1].value = "out";
+
+            await callback(formItems, indexed);
+
+            expect(sanitizedContent).toContain("```js:other-plugin:func");
+            expect(sanitizedContent).toContain("```javascript");
+        });
+
         test("applies Mustache view model to note content", async () => {
             const folder = createFolder('out');
             const getFolderByPath = jest.fn().mockReturnValue(folder);

--- a/src/tests/templateValidator.test.ts
+++ b/src/tests/templateValidator.test.ts
@@ -67,6 +67,26 @@ describe("validateTemplate", () => {
             expect(result.valid).toBe(true);
         });
 
+        test("accepts ref to function name", () => {
+            const result = validateTemplate(validTemplate({ "file-name": "ref:getFileName" }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("accepts ref to file path and function name", () => {
+            const result = validateTemplate(validTemplate({ "file-name": "ref:/utils/helpers.md:getFileName" }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("rejects ref with invalid function name", () => {
+            const result = validateTemplate(validTemplate({ "file-name": "ref:1bad" }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("rejects ref with empty name", () => {
+            const result = validateTemplate(validTemplate({ "file-name": "ref:" }));
+            expect(result.valid).toBe(false);
+        });
+
         test("rejects plain string", () => {
             const result = validateTemplate(validTemplate({ "file-name": "just a name" }));
             expect(result.valid).toBe(false);
@@ -114,6 +134,26 @@ describe("validateTemplate", () => {
         test("accepts get-function type (f:function(view) { ... })", () => {
             const result = validateTemplate(validTemplate({ "file-location": 'f:function(view) { return "some text"; }' }));
             expect(result.valid).toBe(true);
+        });
+
+        test("accepts ref to function name", () => {
+            const result = validateTemplate(validTemplate({ "file-location": "ref:getLocation" }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("accepts ref to file path and function name", () => {
+            const result = validateTemplate(validTemplate({ "file-location": "ref:/utils/helpers.md:getLocation" }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("rejects ref with invalid function name", () => {
+            const result = validateTemplate(validTemplate({ "file-location": "ref:1bad" }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("rejects ref with empty name", () => {
+            const result = validateTemplate(validTemplate({ "file-location": "ref:" }));
+            expect(result.valid).toBe(false);
         });
 
         test("rejects plain string", () => {
@@ -297,8 +337,111 @@ describe("validateTemplate", () => {
             }));
             expect(result.valid).toBe(false);
             expect(result.errors).toEqual(expect.arrayContaining([
-                "/form-items/0/get: must be a function string starting with 'f:' followed by an anonymous function that receives 'view' parameter (e.g. f:(view) => value or f:function(view) { return value; })",
+                "/form-items/0/get: must be a function string starting with 'f:' followed by an arrow function receiving 'view' parameter (e.g. f:(view) => value)",
             ]));
+        });
+
+        test("accepts get with ref to function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ get: "ref:myGetter" })],
+            }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("accepts get with ref to file path and function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ get: "ref:/my/dir/functions.md:myGetter" })],
+            }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("rejects get ref with invalid function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ get: "ref:1bad" })],
+            }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("rejects get ref with empty function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ get: "ref:" })],
+            }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("rejects get ref:path with invalid function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ get: "ref:/path/to/file.md:123bad" })],
+            }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("accepts init with ref to function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:myFunction" })],
+            }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("accepts init with ref to function name starting with $ or _", () => {
+            const result1 = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:$helper" })],
+            }));
+            expect(result1.valid).toBe(true);
+
+            const result2 = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:_private" })],
+            }));
+            expect(result2.valid).toBe(true);
+        });
+
+        test("accepts init with ref to file path and function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:/my/dir/functions.md:myFunc" })],
+            }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("accepts init with ref to single-segment file path", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:/functions.md:init" })],
+            }));
+            expect(result.valid).toBe(true);
+        });
+
+        test("rejects init ref with invalid function name (starts with number)", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:1bad" })],
+            }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("rejects init ref with empty function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:" })],
+            }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("rejects init ref:path with invalid function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:/path/to/file.md:123bad" })],
+            }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("rejects init ref:path without function name", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "ref:/path/to/file.md:" })],
+            }));
+            expect(result.valid).toBe(false);
+        });
+
+        test("rejects init with plain ref (no prefix)", () => {
+            const result = validateTemplate(validTemplate({
+                "form-items": [validTextItem({ init: "myFunction" })],
+            }));
+            expect(result.valid).toBe(false);
         });
     });
 

--- a/src/tests/textFormItem.test.ts
+++ b/src/tests/textFormItem.test.ts
@@ -13,41 +13,55 @@ jest.mock("src/ui/settingsExtension", () => {
     return { ExtendedSetting: jest.fn().mockImplementation(() => ({ ...mock })) };
 });
 
+const mockFunctionProcessor = {
+    renderMustacheTemplate: jest.fn(),
+    executeFunction: jest.fn().mockImplementation((funcText: string) => {
+        const func = eval(`(${funcText})`);
+        return func();
+    }),
+    executeFunctionWithParam: jest.fn(),
+    executeRefFunction: jest.fn(),
+    executeRefFunctionWithParam: jest.fn(),
+} as any;
+
 describe("TextFormItem", () => {
 
     // ─── constructor ───
 
     describe("constructor", () => {
-        test("defaults to empty string when no init provided", () => {
-            const item = new TextFormItem({ id: "t1", type: "text" });
+        test("defaults to empty string when no init provided", async () => {
+            const item = new TextFormItem({ id: "t1", type: "text" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe("");
         });
 
-        test("parses v: init value", () => {
-            const item = new TextFormItem({ id: "t1", type: "text", init: "v:hello" });
+        test("parses v: init value", async () => {
+            const item = new TextFormItem({ id: "t1", type: "text", init: "v:hello" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe("hello");
         });
 
-        test("evaluates f: init function", () => {
-            const item = new TextFormItem({ id: "t1", type: "text", init: "f:() => 'computed'" });
+        test("evaluates f: init function", async () => {
+            const item = new TextFormItem({ id: "t1", type: "text", init: "f:() => 'computed'" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.value).toBe("computed");
         });
 
         test("accepts text type", () => {
-            expect(() => new TextFormItem({ id: "t1", type: "text" })).not.toThrow();
+            expect(() => new TextFormItem({ id: "t1", type: "text" }, mockFunctionProcessor)).not.toThrow();
         });
 
         test("accepts textArea type", () => {
-            expect(() => new TextFormItem({ id: "t1", type: "textArea" })).not.toThrow();
+            expect(() => new TextFormItem({ id: "t1", type: "textArea" }, mockFunctionProcessor)).not.toThrow();
         });
 
         test("throws for unsupported type", () => {
-            expect(() => new TextFormItem({ id: "t1", type: "number" as any }))
+            expect(() => new TextFormItem({ id: "t1", type: "number" as any }, mockFunctionProcessor))
                 .toThrow("Unsupported type");
         });
 
         test("sets id and type correctly", () => {
-            const item = new TextFormItem({ id: "myText", type: "textArea" });
+            const item = new TextFormItem({ id: "myText", type: "textArea" }, mockFunctionProcessor);
             expect(item.id).toBe("myText");
             expect(item.type).toBe("textArea");
         });
@@ -56,18 +70,21 @@ describe("TextFormItem", () => {
     // ─── get ───
 
     describe("get", () => {
-        test("returns value when no getFunc", () => {
-            const item = new TextFormItem({ id: "t1", type: "text", init: "v:world" });
+        test("returns value when no getFunc", async () => {
+            const item = new TextFormItem({ id: "t1", type: "text", init: "v:world" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("world");
         });
 
-        test("returns empty string for default value", () => {
-            const item = new TextFormItem({ id: "t1", type: "text" });
+        test("returns empty string for default value", async () => {
+            const item = new TextFormItem({ id: "t1", type: "text" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("");
         });
 
-        test("returns literal for v: getFunc", () => {
-            const item = new TextFormItem({ id: "t1", type: "text", get: "v:override" });
+        test("returns literal for v: getFunc", async () => {
+            const item = new TextFormItem({ id: "t1", type: "text", get: "v:override" }, mockFunctionProcessor);
+            await item.initialize();
             expect(item.get({})).toBe("override");
         });
     });
@@ -75,25 +92,58 @@ describe("TextFormItem", () => {
     // ─── assignToForm ───
 
     describe("assignToForm", () => {
-        test("does nothing when no form display is configured", () => {
-            const item = new TextFormItem({ id: "t1", type: "text" });
+        test("does nothing when no form display is configured", async () => {
+            const item = new TextFormItem({ id: "t1", type: "text" }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("does not throw for text type with form", () => {
+        test("does not throw for text type with form", async () => {
             const item = new TextFormItem({
                 id: "t1", type: "text",
                 form: { title: "Enter text", placeholder: "type here" },
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
         });
 
-        test("does not throw for textArea type with form", () => {
+        test("does not throw for textArea type with form", async () => {
             const item = new TextFormItem({
                 id: "t1", type: "textArea",
                 form: { title: "Enter text" },
-            });
+            }, mockFunctionProcessor);
+            await item.initialize();
             expect(() => item.assignToForm({} as HTMLElement)).not.toThrow();
+        });
+    });
+
+    // ─── initialize ───
+
+    describe("initialize", () => {
+        test("value is undefined before initialize", () => {
+            const item = new TextFormItem({ id: "t1", type: "text", init: "v:hello" }, mockFunctionProcessor);
+            expect(item.value).toBeUndefined();
+        });
+
+        test("resolves ref: init via executeRefFunction", async () => {
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce("from-ref");
+            const item = new TextFormItem({ id: "t1", type: "text", init: "ref:myFunc" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("myFunc");
+            expect(item.value).toBe("from-ref");
+        });
+
+        test("resolves ref: with path via executeRefFunction", async () => {
+            mockFunctionProcessor.executeRefFunction.mockResolvedValueOnce("from-file-ref");
+            const item = new TextFormItem({ id: "t1", type: "text", init: "ref:/path/to/file.md:myFunc" }, mockFunctionProcessor);
+            await item.initialize();
+            expect(mockFunctionProcessor.executeRefFunction).toHaveBeenCalledWith("/path/to/file.md:myFunc");
+            expect(item.value).toBe("from-file-ref");
+        });
+
+        test("throws for unsupported init prefix", async () => {
+            const item = new TextFormItem({ id: "t1", type: "text", init: "x:bad" as any }, mockFunctionProcessor);
+            await expect(item.initialize()).rejects.toThrow("Unsupported init function");
         });
     });
 });


### PR DESCRIPTION
Add support for `ref:` in `get` and `init` functions to reference code from code blocks in same or different files